### PR TITLE
fix(MetadataWidget): enable re-render if prop changes

### DIFF
--- a/src/components/widgets/MetadataWidget/BreadcrumbWidget/BreadcrumbWidget.stories.tsx
+++ b/src/components/widgets/MetadataWidget/BreadcrumbWidget/BreadcrumbWidget.stories.tsx
@@ -29,7 +29,7 @@ export default {
     ontologyID: {
       description: "Ontology ID from where the object description should be taken.",
     },
-  objType: {
+  entityType: {
     description: "Sets the type of the object whose description you want to fetch. Accepts 'ontology', 'term', 'class', 'property', or 'individual'.",
     control: {
       type: "radio",
@@ -97,6 +97,6 @@ BreadcrumbWidget1.args = {
   iri: "http://purl.obolibrary.org/obo/NCIT_C2985",
   api: "https://semanticlookup.zbmed.de/api/",
   ontologyID: "ncit",
-  objType: "term",
+  entityType: "term",
   parameter: "collection=nfdi4health",
 };

--- a/src/components/widgets/MetadataWidget/BreadcrumbWidget/BreadcrumbWidget.tsx
+++ b/src/components/widgets/MetadataWidget/BreadcrumbWidget/BreadcrumbWidget.tsx
@@ -5,12 +5,12 @@ import {useQuery} from "react-query";
 
 export interface BreadcrumbWidgetProps {
   iri?: string;
-  ontologyID?: string;
+  ontologyId?: string;
   api: string;
   /**
    * This parameter specifies which set of ontologies should be shown for a specific frontend like 'nfdi4health'
    */
-  objType:
+  entityType:
       | "term" | "class" //equivalent: API uses 'class', rest uses 'term' -> both allowed here
       | "individual"
       | "property"
@@ -31,9 +31,9 @@ export interface BreadcrumbWidgetProps {
 
 const NO_SHORTFORM = "No short form available.";
 
-async function getShortForm(olsApi: OlsApi, objType: string, ontologyID?: string, iri?: string, parameter?: string): Promise<string> {
-  if (objType == "term"){
-    const response = await olsApi.getTerm(undefined, undefined, {ontologyId: ontologyID, termIri: iri}, parameter)
+async function getShortForm(olsApi: OlsApi, entityType: string, ontologyId?: string, iri?: string, parameter?: string): Promise<string> {
+  if (entityType == "term"){
+    const response = await olsApi.getTerm(undefined, undefined, {ontologyId: ontologyId, termIri: iri}, parameter)
         .catch((error) => console.log(error));
     if (response?._embedded?.terms[0].short_form != null && response._embedded.terms[0].short_form != null) {
       return response._embedded.terms[0].short_form.toUpperCase();
@@ -41,8 +41,8 @@ async function getShortForm(olsApi: OlsApi, objType: string, ontologyID?: string
       return NO_SHORTFORM;
     }
   }
-  if (objType == "property"){
-    const response = await olsApi.getProperty(undefined, undefined, {ontologyId: ontologyID, propertyIri: iri}, parameter)
+  if (entityType == "property"){
+    const response = await olsApi.getProperty(undefined, undefined, {ontologyId: ontologyId, propertyIri: iri}, parameter)
         .catch((error) => console.log(error));
     if (response?._embedded?.properties[0].short_form != null && response._embedded.properties[0].short_form != null) {
       return response._embedded.properties[0].short_form;
@@ -50,8 +50,8 @@ async function getShortForm(olsApi: OlsApi, objType: string, ontologyID?: string
       return NO_SHORTFORM;
     }
   }
-  if (objType == "individual"){
-    const response = await olsApi.getIndividual(undefined, undefined, {ontologyId: ontologyID, individualIri: iri}, parameter)
+  if (entityType == "individual"){
+    const response = await olsApi.getIndividual(undefined, undefined, {ontologyId: ontologyId, individualIri: iri}, parameter)
         .catch((error) => console.log(error));
     if (response?._embedded?.individuals[0].short_form != null && response._embedded.individuals[0].short_form != null) {
       return response._embedded.individuals[0].short_form;
@@ -64,19 +64,19 @@ async function getShortForm(olsApi: OlsApi, objType: string, ontologyID?: string
 }
 
 function BreadcrumbWidget(props: BreadcrumbWidgetProps) {
-  const { api, ontologyID, iri, objType, colorFirst, colorSecond, parameter } = props;
-  const fixedObjType = objType == "class" ? "term" : objType
+  const { api, ontologyId, iri, entityType, colorFirst, colorSecond, parameter } = props;
+  const fixedEntityType = entityType == "class" ? "term" : entityType
   const olsApi = new OlsApi(api);
 
   const {
     data: shortForm,
     isLoading,
-  } = useQuery([api, "getDescription", fixedObjType, ontologyID, iri, parameter], () => { return getShortForm(olsApi, fixedObjType, ontologyID, iri, parameter); });
+  } = useQuery([api, "getDescription", fixedEntityType, ontologyId, iri, parameter], () => { return getShortForm(olsApi, fixedEntityType, ontologyId, iri, parameter); });
 
   return (
     <EuiFlexItem>
       <span>
-        <EuiBadge color={colorFirst || "primary"}>{ontologyID?.toUpperCase()}</EuiBadge>
+        <EuiBadge color={colorFirst || "primary"}>{ontologyId?.toUpperCase()}</EuiBadge>
         {" > "}
         <EuiBadge color={colorSecond || "success"}>{shortForm}</EuiBadge>
       </span>

--- a/src/components/widgets/MetadataWidget/DescriptionWidget/DescriptionWidget.stories.tsx
+++ b/src/components/widgets/MetadataWidget/DescriptionWidget/DescriptionWidget.stories.tsx
@@ -44,7 +44,7 @@ export default {
     ontologyID: {
       description: "Ontology ID from where the object description should be taken.",
     },
-    objType: {
+    entityType: {
       description: "Sets the type of the object whose description you want to fetch. Accepts 'ontology', 'term', 'class', 'property', or 'individual'.",
       control: {
         type: "radio",
@@ -84,6 +84,6 @@ DescriptionWidget1.args = {
   iri: "http://purl.obolibrary.org/obo/NCIT_C2985",
   api: "https://semanticlookup.zbmed.de/api/",
   ontologyID: "ncit",
-  objType: "term",
+  entityType: "term",
   parameter: "collection=nfdi4health"
 };

--- a/src/components/widgets/MetadataWidget/DescriptionWidget/DescriptionWidget.tsx
+++ b/src/components/widgets/MetadataWidget/DescriptionWidget/DescriptionWidget.tsx
@@ -6,10 +6,10 @@ import { OlsApi } from "../../../../api/OlsApi";
 
 export interface DescriptionWidgetProps extends EuiTextProps {
   iri?: string;
-  ontologyID?: string;
+  ontologyId?: string;
   api: string;
   descText?: string;
-  objType:
+  entityType:
     | "ontology"
     | "term" | "class" //equivalent: API uses 'class', rest uses 'term' -> both allowed here
     | "individual"
@@ -20,14 +20,14 @@ export interface DescriptionWidgetProps extends EuiTextProps {
 
 const NO_DESCRIPTION = "No description available.";
 
-async function getDescription(olsApi: OlsApi, objType: string, ontologyID?: string, iri?: string, parameter?: string): Promise<string> {
-  if (objType == "ontology"){
-    const response = await olsApi.getOntology(undefined, undefined, {ontologyId: ontologyID}, parameter)
+async function getDescription(olsApi: OlsApi, entityType: string, ontologyId?: string, iri?: string, parameter?: string): Promise<string> {
+  if (entityType == "ontology"){
+    const response = await olsApi.getOntology(undefined, undefined, {ontologyId: ontologyId}, parameter)
       .catch((error) => console.log(error));
     return response?.config.description || NO_DESCRIPTION;
   }
-  if (objType == "term"){
-    const response = await olsApi.getTerm(undefined, undefined, {ontologyId: ontologyID, termIri: iri}, parameter)
+  if (entityType == "term"){
+    const response = await olsApi.getTerm(undefined, undefined, {ontologyId: ontologyId, termIri: iri}, parameter)
       .catch((error) => console.log(error));
     if (response?._embedded?.terms[0].description != null && response._embedded.terms[0].description[0] != null) {
       return response._embedded.terms[0].description[0];
@@ -35,8 +35,8 @@ async function getDescription(olsApi: OlsApi, objType: string, ontologyID?: stri
       return NO_DESCRIPTION;
     }
   }
-  if (objType == "property"){
-    const response = await olsApi.getProperty(undefined, undefined, {ontologyId: ontologyID, propertyIri: iri}, parameter)
+  if (entityType == "property"){
+    const response = await olsApi.getProperty(undefined, undefined, {ontologyId: ontologyId, propertyIri: iri}, parameter)
       .catch((error) => console.log(error));
     if (response?._embedded?.properties[0].description != null && response._embedded.properties[0].description[0] != null) {
       return response._embedded.properties[0].description[0];
@@ -44,8 +44,8 @@ async function getDescription(olsApi: OlsApi, objType: string, ontologyID?: stri
       return NO_DESCRIPTION;
     }
   }
-  if (objType == "individual"){
-    const response = await olsApi.getIndividual(undefined, undefined, {ontologyId: ontologyID, individualIri: iri}, parameter)
+  if (entityType == "individual"){
+    const response = await olsApi.getIndividual(undefined, undefined, {ontologyId: ontologyId, individualIri: iri}, parameter)
       .catch((error) => console.log(error));
     if (response?._embedded?.individuals[0].description != null && response._embedded.individuals[0].description[0] != null) {
       return response._embedded.individuals[0].description[0];
@@ -58,14 +58,14 @@ async function getDescription(olsApi: OlsApi, objType: string, ontologyID?: stri
 }
 
 function DescriptionWidget(props: DescriptionWidgetProps) {
-  const { api, ontologyID, iri, descText, objType, parameter, ...rest } = props;
-  const fixedObjType = objType == "class" ? "term" : objType
+  const { api, ontologyId, iri, descText, entityType, parameter, ...rest } = props;
+  const fixedentityType = entityType == "class" ? "term" : entityType
   const olsApi = new OlsApi(api);
 
   const {
     data: description,
     isLoading,
-  } = useQuery([api, "getDescription", fixedObjType, ontologyID, iri, parameter], () => { return getDescription(olsApi, fixedObjType, ontologyID, iri, parameter); });
+  } = useQuery([api, "getDescription", fixedentityType, ontologyId, iri, parameter], () => { return getDescription(olsApi, fixedentityType, ontologyId, iri, parameter); });
 
   return (
     <>

--- a/src/components/widgets/MetadataWidget/MetadataWidget.stories.tsx
+++ b/src/components/widgets/MetadataWidget/MetadataWidget.stories.tsx
@@ -20,13 +20,13 @@ export default {
         ],
       },
     },
-    ontologyID: {
+    ontologyId: {
       description: "Ontology ID from where the term metadata should be taken.",
     },
     iri: {
       description: "Iri of the term you want to fetch the metadata for.",
     },
-    objType: {
+    entityType: {
       description: "Sets the type of the object whose description you want to fetch. Accepts 'ontology', 'term', 'class', 'property', or 'individual'.",
       control: {
         type: "radio",
@@ -59,8 +59,8 @@ export const MetadataWidget1 = Template.bind({});
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 MetadataWidget1.args = {  api: "https://semanticlookup.zbmed.de/api/",
-  ontologyID: "ncit",
+  ontologyId: "ncit",
   iri: "http://purl.obolibrary.org/obo/NCIT_C2984",
-  objType: "term",
+  entityType: "term",
   parameter: "collection=nfdi4health"
 };

--- a/src/components/widgets/MetadataWidget/MetadataWidget.tsx
+++ b/src/components/widgets/MetadataWidget/MetadataWidget.tsx
@@ -8,9 +8,9 @@ import { TabWidget } from "./TabWidget";
 
 export interface MetadataWidgetProps {
   iri: string;
-  ontologyID: string;
+  ontologyId: string;
   api: string;
-  objType:
+  entityType:
     | "term" | "class" //equivalent: API uses 'class', rest uses 'term' -> both allowed here
     | "individual"
     | "property"
@@ -19,11 +19,12 @@ export interface MetadataWidgetProps {
 }
 
 function MetadataWidget(props: MetadataWidgetProps) {
+    const { iri, api, parameter, entityType, ontologyId } = props;
   return (
     <EuiFlexGroup direction="column" style={{ maxWidth: 600 }}>
       <EuiFlexItem grow={false}>
         <span>
-          <BreadcrumbWidget api={props.api} iri={props.iri} objType={props.objType} ontologyID={props.ontologyID} parameter={props.parameter}/>
+          <BreadcrumbWidget api={api} iri={iri} entityType={entityType} ontologyId={ontologyId} parameter={parameter}/>
         </span>
       </EuiFlexItem>
       <EuiFlexItem>
@@ -31,26 +32,26 @@ function MetadataWidget(props: MetadataWidgetProps) {
           <EuiFlexItem>
             <EuiFlexGroup>
               <EuiFlexItem grow={false}>
-                <IriWidget iri={props.iri} parameter={props.parameter}/>
+                <IriWidget iri={iri} parameter={parameter}/>
               </EuiFlexItem>
             </EuiFlexGroup>
           </EuiFlexItem>
 
           <EuiFlexItem grow={false}>
-            <TitleWidget iri={props.iri} ontologyID={props.ontologyID} api={props.api} objType={"term"} parameter={props.parameter} />
+            <TitleWidget iri={iri} ontologyId={ontologyId} api={api} entityType={entityType} parameter={parameter} />
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiFlexItem>
       <EuiFlexItem>
-        <DescriptionWidget iri={props.iri} ontologyID={props.ontologyID} api={props.api} objType={"term"} parameter={props.parameter}/>
+        <DescriptionWidget iri={iri} ontologyId={ontologyId} api={api} entityType={entityType} parameter={parameter}/>
       </EuiFlexItem>
       <EuiFlexItem>
         <TabWidget
-          iri={props.iri}
-          ontologyID={props.ontologyID}
-          api={props.api}
-          parameter={props.parameter}
-        />
+          iri={iri}
+          ontologyId={ontologyId}
+          api={api}
+          parameter={parameter}
+         entityType={entityType}/>
       </EuiFlexItem>
     </EuiFlexGroup>
   );

--- a/src/components/widgets/MetadataWidget/TabWidget/AlternativeNameTabWidget/AlternativeNameTabWidget.stories.tsx
+++ b/src/components/widgets/MetadataWidget/TabWidget/AlternativeNameTabWidget/AlternativeNameTabWidget.stories.tsx
@@ -26,6 +26,22 @@ export default {
       description:
         "Iri of the term you want to fetch the alternative names for.",
     },
+    ontologyId: {
+      description: "Ontology ID from where the entity metadata should be taken.",
+    },
+    entityType: {
+      description: "Sets the type of the entity whose information you want to fetch. Accepts 'term', 'class', 'property', or 'individual'.",
+      control: {
+        type: "radio",
+        options: [
+          "term",
+          "class",
+          "property",
+          "individual",
+          "INVALID STRING"
+        ],
+      },
+    },
     parameter: {
       defaultValue: "collection=nfdi4health",
       type: { required: false }
@@ -42,5 +58,8 @@ export const AlternativeNameTabWidget1 = Template.bind({});
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 AlternativeNameTabWidget1.args = {
-  iri: "http://purl.obolibrary.org/obo/NCIT_C2985",  api: "https://semanticlookup.zbmed.de/api/",
+  iri: "http://purl.obolibrary.org/obo/NCIT_C2985",
+  api: "https://semanticlookup.zbmed.de/api/",
+  entityType: "term",
+  ontologyId: "ncit",
 };

--- a/src/components/widgets/MetadataWidget/TabWidget/CrossRefWidget/CrossRefTabWidget.stories.tsx
+++ b/src/components/widgets/MetadataWidget/TabWidget/CrossRefWidget/CrossRefTabWidget.stories.tsx
@@ -21,7 +21,23 @@ export default {
     },
     iri: {
       description:
-        "Iri of the term you want to fetch the cross references for.",
+        "IRI of the entity you want to fetch the cross references for.",
+    },
+    ontologyId: {
+      description: "Ontology ID from where the entity metadata should be taken.",
+    },
+    entityType: {
+      description: "Sets the type of the entity whose information you want to fetch. Accepts 'term', 'class', 'property', or 'individual'.",
+      control: {
+        type: "radio",
+        options: [
+          "term",
+          "class",
+          "property",
+          "individual",
+          "INVALID STRING"
+        ],
+      },
     },
     parameter: {
       defaultValue: "collection=nfdi4health",
@@ -39,4 +55,6 @@ export const CrossRefTabWidget1 = Template.bind({});
 CrossRefTabWidget1.args = {
   iri: "http://purl.obolibrary.org/obo/RXNO_0000138",
   api: "https://www.ebi.ac.uk/ols/api/",
+  entityType: "term",
+  ontologyId: "rxno"
 };

--- a/src/components/widgets/MetadataWidget/TabWidget/CrossRefWidget/CrossRefTabWidget.tsx
+++ b/src/components/widgets/MetadataWidget/TabWidget/CrossRefWidget/CrossRefTabWidget.tsx
@@ -2,44 +2,82 @@ import React, { useEffect, useState } from "react";
 import {
   EuiFlexGroup,
   EuiFlexItem,
-  EuiLink,
+  EuiLink, EuiLoadingSpinner,
   EuiPanel,
   EuiText,
 } from "@elastic/eui";
+import { OlsApi } from '../../../../../api/OlsApi'
+import { useQuery } from 'react-query'
 
 export interface CrossRefWidgetProps {
   iri: string;
   api: string;
-  parameter?: string
+  ontologyId?: string;
+  entityType:
+      | "ontology"
+      | "term" | "class" //equivalent: API uses 'class', rest uses 'term' -> both allowed here
+      | "individual"
+      | "property"
+      | string;
+  parameter?: string;
+}
+
+interface CrossRefs {
+    crossrefs: [{
+      database: string,
+      id: string,
+      url: string
+    }]
+}
+
+async function getCorssRefs(olsApi: OlsApi, entityType: string, iri?: string, ontologyId?: string, parameter?: string): Promise<CrossRefs> {
+    if (entityType == "term" || entityType == "class") {
+        const response = await olsApi.getTerm(undefined, undefined, {ontologyId: ontologyId, termIri: iri}, parameter)
+          .catch((error) => console.log(error));
+        return {
+            crossrefs: response._embedded.terms[0].obo_xref,
+        };
+    }
+    if (entityType == "property") {
+        const response = await olsApi.getProperty(undefined, undefined, {ontologyId: ontologyId, propertyIri: iri}, parameter)
+          .catch((error) => console.log(error));
+        return {
+            crossrefs: response._embedded.properties[0].obo_xref,
+        };
+    }
+    if (entityType == "individual") {
+        const response = await olsApi.getIndividual(undefined, undefined, {ontologyId: ontologyId, individualIri: iri}, parameter)
+          .catch((error) => console.log(error));
+        return {
+            crossrefs: response._embedded.individuals[0].obo_xref,
+        };
+    }
+    return {
+       crossrefs : [{
+         database: "",
+         id: "",
+         url: ""
+       }],
+    };
 }
 
 function CrossRefTabWidget(props: CrossRefWidgetProps) {
-  const [crossRef, setCrossRef] =
-    useState<{ url: string; database: string; id: string }[]>();
-  const { iri, api } = props;
+  const { iri, api, parameter, entityType, ontologyId } = props;
+  const olsApi = new OlsApi(api);
 
-  useEffect(() => {
-    const getDescription = async () => {
-      const crossRefData = await fetch(`${api}terms?iri=${iri}`, {
-        method: "GET",
-        headers: {
-          Accept: "application/json",
-          Content_Type: "application/json",
-        },
-      })
-        .then((response) => response.json())
-        .then((response) => response._embedded.terms[0].obo_xref);
-      setCrossRef(crossRefData);
-    };
-    getDescription().catch((error) => console.log(error));
-  }, [api, iri]);
+  const {
+        data,
+        isLoading,
+        isSuccess,
+        isError,
+    } = useQuery([api, iri, ontologyId, entityType, parameter, "entityInfo"], () => {
+        return getCorssRefs(olsApi, entityType, iri, ontologyId);
+    });
 
-  return (
-    <EuiPanel>
-      <EuiFlexGroup style={{ padding: 7 }} direction="column">
-        {crossRef ? (
-          crossRef.map((item, index) => (
-            <EuiFlexItem key={index}>
+  function renderCrossRefs() {
+    if (data?.crossrefs && data.crossrefs.length > 0) {
+      return data?.crossrefs.map((item, index) => (
+        <EuiFlexItem key={index}>
               {item.url ? (
                 <EuiLink href={item.url} external target="_blank">
                   {item.database}:{item.id}
@@ -48,10 +86,17 @@ function CrossRefTabWidget(props: CrossRefWidgetProps) {
                 `${item.database}:${item.id}`
               )}
             </EuiFlexItem>
-          ))
-        ) : (
-          <EuiText>No cross references exists for this concept.</EuiText>
-        )}
+      ));
+    }
+    return <EuiText>No cross references exist.</EuiText>;
+  }
+
+  return (
+    <EuiPanel>
+      <EuiFlexGroup style={{ padding: 7 }} direction="column">
+        {isSuccess && renderCrossRefs()}
+        {isLoading && <EuiLoadingSpinner></EuiLoadingSpinner>}
+        {isError && <EuiText>No cross references available.</EuiText>}
       </EuiFlexGroup>
     </EuiPanel>
   );

--- a/src/components/widgets/MetadataWidget/TabWidget/HierarchyWidget/HierarchyWidget.stories.tsx
+++ b/src/components/widgets/MetadataWidget/TabWidget/HierarchyWidget/HierarchyWidget.stories.tsx
@@ -22,7 +22,7 @@ export default {
     frontend: {
       defaultValue: "nfdi4health",
     },
-    ontologyID: {
+    ontologyId: {
       description: "Ontology ID from where the term hierarchy should be taken.",
     },
     iri: {
@@ -40,6 +40,6 @@ export const HierarchyWidget1 = Template.bind({});
 HierarchyWidget1.args = {
   iri: "http://purl.bioontology.org/ontology/MESH/D003704",
   api: "https://semanticlookup.zbmed.de/api/",
-  ontologyID: "mesh",
+  ontologyId: "mesh",
   frontend: "nfdi4health",
 };

--- a/src/components/widgets/MetadataWidget/TabWidget/HierarchyWidget/HierarchyWidget.tsx
+++ b/src/components/widgets/MetadataWidget/TabWidget/HierarchyWidget/HierarchyWidget.tsx
@@ -93,12 +93,12 @@ const create_tree = (
 
 export interface HierarchyWidgetProps {
   iri?: string;
-  ontologyID: string;
+  ontologyId: string;
   api: string;
 }
 
-async function getTree(olsApi: OlsApi, ontologyID: string, iri?: string): Promise<any> {
-  const response = await olsApi.getTermTree({ontologyId: ontologyID, termIri: iri}, {viewMode: "All", siblings: false}, undefined, undefined)
+async function getTree(olsApi: OlsApi, ontologyId: string, iri?: string): Promise<any> {
+  const response = await olsApi.getTermTree({ontologyId: ontologyId, termIri: iri}, {viewMode: "All", siblings: false}, undefined, undefined)
     .catch((error) => console.log(error));
   if (iri) return response
   else { //roots have been queried, and the response needs restructuring to become SemanticResponse
@@ -110,21 +110,21 @@ async function getTree(olsApi: OlsApi, ontologyID: string, iri?: string): Promis
 }
 
 const HierarchyWidget = (props: HierarchyWidgetProps) => {
-  const { iri, ontologyID, api } = props;
+  const { iri, ontologyId, api } = props;
   const [treeItems, setTreeItems] = useState<HierarchyTree[]>();
   const olsApi = new OlsApi(api);
-  const linkToSelf = api+"ontologies/"+ontologyID+"/terms/"
+  const linkToSelf = api+"ontologies/"+ontologyId+"/terms/"
 
   const fetchChildren = async (child: HierarchyTree) => { //could be given to HierarchyTree nodes for onClick callbacks
-    const response = await olsApi.getTermTree({ontologyId: ontologyID, termIri: iri}, {child: child.id}, undefined, undefined)
+    const response = await olsApi.getTermTree({ontologyId: ontologyId, termIri: iri}, {child: child.id}, undefined, undefined)
       .catch((error) => console.log(error));
     child.children = [];
     create_tree(child, response, get_url_prefix(linkToSelf));
   }
 
   //initial tree query
-  useQuery<Array<SemanticResponse>>([api, "getTermTree", ontologyID, iri], () => {
-    return getTree(olsApi, ontologyID, iri)
+  useQuery<Array<SemanticResponse>>([api, "getTermTree", ontologyId, iri], () => {
+    return getTree(olsApi, ontologyId, iri)
       .then((res) => {
         const root = new HierarchyTree("#", "#", "", "");
         if (res) create_tree(root, res, get_url_prefix(linkToSelf));

--- a/src/components/widgets/MetadataWidget/TabWidget/TabWidget.stories.tsx
+++ b/src/components/widgets/MetadataWidget/TabWidget/TabWidget.stories.tsx
@@ -29,6 +29,19 @@ export default {
       defaultValue: "collection=nfdi4health",
       type: { required: false }
     },
+    entityType: {
+      description: "Sets the type of the entity whose information you want to fetch. Accepts 'term', 'class', 'property', or 'individual'.",
+      control: {
+        type: "radio",
+        options: [
+          "term",
+          "class",
+          "property",
+          "individual",
+          "INVALID STRING"
+        ],
+      },
+    },
   },
 };
 
@@ -38,7 +51,9 @@ export const TabWidget1 = Template.bind({});
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
-TabWidget1.args = {  api: "https://semanticlookup.zbmed.de/api/",
+TabWidget1.args = {
+  api: "https://semanticlookup.zbmed.de/api/",
   ontologyID: "ncit",
   iri: "http://purl.obolibrary.org/obo/NCIT_C2985",
+  entityType: "term"
 };

--- a/src/components/widgets/MetadataWidget/TabWidget/TabWidget.tsx
+++ b/src/components/widgets/MetadataWidget/TabWidget/TabWidget.tsx
@@ -10,27 +10,44 @@ import { HierarchyWidget } from "./HierarchyWidget";
 
 export interface TabWidgetProps {
   iri: string;
-  ontologyID: string;
   api: string;
-  parameter?: string
+  ontologyId: string;
+  entityType:
+      | "ontology"
+      | "term" | "class" //equivalent: API uses 'class', rest uses 'term' -> both allowed here
+      | "individual"
+      | "property"
+      | string;
+  parameter?: string;
 }
 
 function TabWidget(props: TabWidgetProps) {
+  const { iri, api, ontologyId, entityType, parameter, ...rest } = props;
   const tabs: Array<EuiTabbedContentTab> = [
     {
-      content: <AlternativeNameTabWidget api={props.api} iri={props.iri} />,
+      content: <AlternativeNameTabWidget
+          api={api}
+          iri={iri}
+          ontologyId={ontologyId}
+          entityType={entityType}
+      />,
       id: "tab1",
       name: "Alternative Names",
     },
     {
       content: (
-        <HierarchyWidget api={props.api} iri={props.iri} ontologyID={props.ontologyID} />
+        <HierarchyWidget api={api} iri={iri} ontologyId={ontologyId} />
       ),
       id: "tab2",
       name: "Hierarchy",
     },
     {
-      content: <CrossRefTabWidget api={props.api} iri={props.iri} />,
+      content: <CrossRefTabWidget
+          api={api}
+          iri={iri}
+          ontologyId={ontologyId}
+          entityType={entityType}
+      />,
       id: "tab3",
       name: "Cross references",
     },

--- a/src/components/widgets/MetadataWidget/TitleWidget/TitleWidget.stories.tsx
+++ b/src/components/widgets/MetadataWidget/TitleWidget/TitleWidget.stories.tsx
@@ -23,7 +23,7 @@ export default {
     ontologyID: {
       description: "Ontology ID from where the object title/label should be taken.",
     },
-    objType: {
+    entityType: {
       description: "Sets the type of the object whose title/label you want to fetch. Accepts 'ontology', 'term', 'class', 'property', or 'individual'.",
       control: {
         type: "radio",
@@ -66,5 +66,5 @@ export const TitleWidget1 = Template.bind({});
 TitleWidget1.args = {
   iri: "http://purl.obolibrary.org/obo/NCIT_C2985",  api: "https://semanticlookup.zbmed.de/api/",
   ontologyID: "ncit",
-  objType: "term",
+  entityType: "term",
 };

--- a/src/components/widgets/MetadataWidget/TitleWidget/TitleWidget.tsx
+++ b/src/components/widgets/MetadataWidget/TitleWidget/TitleWidget.tsx
@@ -4,60 +4,69 @@ import { EuiLoadingSpinner, EuiText } from "@elastic/eui";
 import { OlsApi } from "../../../../api/OlsApi";
 
 export interface TitleWidgetProps {
-  iri?: string;
-  ontologyID?: string;
-  api: string;
-  titleText?: string;
-  objType:
-    | "ontology"
-    | "term" | "class" //equivalent: API uses 'class', rest uses 'term' -> both allowed here
-    | "individual"
-    | "property"
-    | string;
-  parameter?: string
+    iri?: string;
+    ontologyId?: string;
+    api: string;
+    titleText?: string;
+    entityType:
+        | "ontology"
+        | "term" | "class" //equivalent: API uses 'class', rest uses 'term' -> both allowed here
+        | "individual"
+        | "property"
+        | string;
+    parameter?: string
 }
 
 const NO_TITLE = "No title available.";
 
 
-async function getTitle(olsApi: OlsApi, objType: string, ontologyID?: string, iri?: string, parameter?: string): Promise<string> {
-  if (objType == "ontology") {
-    const response = await olsApi.getOntology(undefined, undefined, {ontologyId: ontologyID}, parameter)
-      .catch((error) => console.log(error));
-    return response?.config.title || NO_TITLE
-  }
-  if (objType == "term") {
-    const response = await olsApi.getTerm(undefined, undefined, {ontologyId: ontologyID, termIri: iri}, parameter)
-      .catch((error) => console.log(error));
-    return response?._embedded?.terms[0].label || NO_TITLE
-  }
-  if (objType == "property") {
-    const response = await olsApi.getProperty(undefined, undefined, {ontologyId: ontologyID, propertyIri: iri}, parameter)
-      .catch((error) => console.log(error));
-    return response?._embedded?.properties[0].label || NO_TITLE
-  }
-  if (objType == "individual"){
-    const response = await olsApi.getIndividual(undefined, undefined, {ontologyId: ontologyID, individualIri: iri}, parameter)
-      .catch((error) => console.log(error));
-    return response?._embedded?.individuals[0].label || NO_TITLE
-  }
-  return NO_TITLE;
+async function getTitle(olsApi: OlsApi, entityType: string, ontologyId?: string, iri?: string, parameter?: string): Promise<string> {
+    if (entityType == "ontology") {
+        const response = await olsApi.getOntology(undefined, undefined, { ontologyId: ontologyId }, parameter)
+            .catch((error) => console.log(error));
+        return response?.config.title || NO_TITLE
+    }
+    if (entityType == "term") {
+        const response = await olsApi.getTerm(undefined, undefined, { ontologyId: ontologyId, termIri: iri }, parameter)
+            .catch((error) => console.log(error));
+        return response?._embedded?.terms[0].label || NO_TITLE
+    }
+    if (entityType == "property") {
+        const response = await olsApi.getProperty(undefined, undefined, {
+            ontologyId: ontologyId,
+            propertyIri: iri
+        }, parameter)
+            .catch((error) => console.log(error));
+        return response?._embedded?.properties[0].label || NO_TITLE
+    }
+    if (entityType == "individual") {
+        const response = await olsApi.getIndividual(undefined, undefined, {
+            ontologyId: ontologyId,
+            individualIri: iri
+        }, parameter)
+            .catch((error) => console.log(error));
+        return response?._embedded?.individuals[0].label || NO_TITLE
+    }
+    return NO_TITLE;
 }
 
 function TitleWidget(props: TitleWidgetProps) {
-  const { iri, ontologyID, api, titleText, objType, parameter } = props;
-  const fixedObjType = objType == "class" ? "term" : objType
-  const olsApi = new OlsApi(api);
+    const { iri, ontologyId, api, titleText, entityType, parameter } = props;
+    const fixedEntityType = entityType == "class" ? "term" : entityType
+    const olsApi = new OlsApi(api);
 
-  const {data: label,
-  isLoading,
-  } = useQuery([api, "getTitle", fixedObjType, ontologyID, iri, parameter], () => { return getTitle(olsApi, fixedObjType, ontologyID, iri, parameter); });
+    const {
+        data: label,
+        isLoading,
+    } = useQuery([api, "getTitle", fixedEntityType, ontologyId, iri, parameter], () => {
+        return getTitle(olsApi, fixedEntityType, ontologyId, iri, parameter);
+    });
 
-  return (
-    <>
-      {isLoading ? <EuiLoadingSpinner size="s" /> : <EuiText>{titleText || label}</EuiText>}
-    </>
-  );
+    return (
+        <>
+            {isLoading ? <EuiLoadingSpinner size="s"/> : <EuiText>{titleText || label}</EuiText>}
+        </>
+    );
 }
 
 export { TitleWidget };

--- a/src/components/widgets/SearchResultsListWidget/MetadataCompact.tsx
+++ b/src/components/widgets/SearchResultsListWidget/MetadataCompact.tsx
@@ -35,7 +35,7 @@ function MetadataCompact(props: MetadataCompactProps) {
                         <EuiTitle><h2>{result.label}</h2></EuiTitle>
                     </EuiFlexItem>
                     <EuiFlexItem>
-                        {result.type != "ontology" && <BreadcrumbWidget api={api} iri={result.iri} objType={result.type} ontologyID={result.ontology_name}/>}
+                        {result.type != "ontology" && <BreadcrumbWidget api={api} iri={result.iri} entityType={result.type} ontologyId={result.ontology_name}/>}
                     </EuiFlexItem>
                 </EuiFlexGroup>
             }
@@ -43,8 +43,8 @@ function MetadataCompact(props: MetadataCompactProps) {
                 <>
                     {result.type != "ontology" ? <IriWidget iri={result.iri}/> : undefined}
                     <EuiSpacer size="s"/>
-                    <DescriptionWidget api={api} ontologyID={result.ontology_name} iri={result.iri}
-                                       objType={result.type}/>
+                    <DescriptionWidget api={api} ontologyId={result.ontology_name} iri={result.iri}
+                                       entityType={result.type}/>
                 </>
             }
         />

--- a/src/utils/ApiUtils.tsx
+++ b/src/utils/ApiUtils.tsx
@@ -1,5 +1,5 @@
-export function switchEntityType(objType: string) {
-    switch (objType) {
+export function switchEntityType(entityType: string) {
+    switch (entityType) {
         case 'class':
             return 'terms';
         case 'property':


### PR DESCRIPTION
The MetadataWidget did not re-render when the prop changed. I fixed this by refactoring (renaming ontologyID to ontologyId and objType to entityType, using Axios and OlsApi) the MetadataWidget and all dependent widgets.