### PR TITLE
Metadata ontology id optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nfdi4health/semlookp-widgets",
-  "version": "1.8.0",
+  "version": "1.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nfdi4health/semlookp-widgets",
-      "version": "1.8.0",
+      "version": "1.10.0",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-typescript": "^8.3.4",

--- a/src/components/widgets/MetadataWidget/BreadcrumbWidget/BreadcrumbWidget.stories.tsx
+++ b/src/components/widgets/MetadataWidget/BreadcrumbWidget/BreadcrumbWidget.stories.tsx
@@ -102,3 +102,23 @@ BreadcrumbWidget1.args = {
   entityType: "term",
   parameter: "collection=nfdi4health",
 };
+
+export const SelectingDefiningOntology = Template.bind({});
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+SelectingDefiningOntology.args = {  api: "https://www.ebi.ac.uk/ols/api/",
+  iri: "http://purl.obolibrary.org/obo/IAO_0000631",
+  entityType: "term",
+  parameter: ""
+};
+
+export const DefiningOntologyUnavailable = Template.bind({});
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+DefiningOntologyUnavailable.args = {  api: "https://www.ebi.ac.uk/ols/api/",
+  iri: "http://identifiers.org/uniprot/Q9VAM9",
+  entityType: "term",
+  parameter: ""
+};

--- a/src/components/widgets/MetadataWidget/BreadcrumbWidget/BreadcrumbWidget.tsx
+++ b/src/components/widgets/MetadataWidget/BreadcrumbWidget/BreadcrumbWidget.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import {EuiBadge, EuiFlexItem, EuiLoadingSpinner, EuiText} from "@elastic/eui";
+import {EuiBadge, EuiFlexItem, EuiLoadingSpinner, EuiText, EuiIconTip} from "@elastic/eui";
 import {OlsApi} from "../../../../api/OlsApi";
 import {useQuery} from "react-query";
 import {getPreferredOntologyJSON} from "../index";
@@ -51,8 +51,13 @@ function BreadcrumbWidget(props: BreadcrumbWidgetProps) {
               {
                   !props.ontologyId && !ontologyJSON["is_defining_ontology"] &&
                   <EuiFlexItem>
-                    <EuiText>
-                      <i>Defining ontology not available. Showing occurrence inside {ontologyJSON["ontology_name"]} instead.</i>
+                    <EuiText size={"s"}>
+                      <i>Defining ontology not available </i>
+                      <EuiIconTip type={"iInCircle"}
+                                  color={"subdued"}
+                                  content={`Showing occurence inside ${ontologyJSON["ontology_name"]} instead.`}
+                      >
+                      </EuiIconTip>
                     </EuiText>
                   </EuiFlexItem>
               }

--- a/src/components/widgets/MetadataWidget/BreadcrumbWidget/BreadcrumbWidget.tsx
+++ b/src/components/widgets/MetadataWidget/BreadcrumbWidget/BreadcrumbWidget.tsx
@@ -8,9 +8,7 @@ export interface BreadcrumbWidgetProps {
   iri: string;
   ontologyId?: string;
   api: string;
-  /**
-   * This parameter specifies which set of ontologies should be shown for a specific frontend like 'nfdi4health'
-   */
+
   entityType:
       | "term" | "class" //equivalent: API uses 'class', rest uses 'term' -> both allowed here
       | "individual"
@@ -27,6 +25,9 @@ export interface BreadcrumbWidgetProps {
     | "subdued"
     | string;
   colorSecond?: string;
+  /**
+   * This parameter specifies which set of ontologies should be shown for a specific frontend like 'nfdi4health'
+   */
   parameter?: string
 }
 

--- a/src/components/widgets/MetadataWidget/DescriptionWidget/DescriptionWidget.stories.tsx
+++ b/src/components/widgets/MetadataWidget/DescriptionWidget/DescriptionWidget.stories.tsx
@@ -87,3 +87,23 @@ DescriptionWidget1.args = {
   entityType: "term",
   parameter: "collection=nfdi4health"
 };
+
+export const SelectingDefiningOntology = Template.bind({});
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+SelectingDefiningOntology.args = {  api: "https://www.ebi.ac.uk/ols/api/",
+  iri: "http://purl.obolibrary.org/obo/IAO_0000631",
+  entityType: "term",
+  parameter: ""
+};
+
+export const DefiningOntologyUnavailable = Template.bind({});
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+DefiningOntologyUnavailable.args = {  api: "https://www.ebi.ac.uk/ols/api/",
+  iri: "http://identifiers.org/uniprot/Q9VAM9",
+  entityType: "term",
+  parameter: ""
+};

--- a/src/components/widgets/MetadataWidget/DescriptionWidget/DescriptionWidget.tsx
+++ b/src/components/widgets/MetadataWidget/DescriptionWidget/DescriptionWidget.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useQuery } from "react-query";
-import {EuiFlexItem, EuiLoadingSpinner, EuiText} from "@elastic/eui";
+import {EuiLoadingSpinner, EuiText} from "@elastic/eui";
 import { EuiTextProps } from "@elastic/eui/src/components/text/text";
 import { OlsApi } from "../../../../api/OlsApi";
 import {getPreferredOntologyJSON} from "../index";
@@ -69,19 +69,21 @@ function DescriptionWidget(props: DescriptionWidgetProps) {
     isSuccess,
   } = useQuery([api, "description", fixedEntityType, ontologyId, iri, parameter], () => {return getDescription(olsApi, fixedEntityType, ontologyId, iri, parameter); });
 
+  // TODO: Should DescriptionWidget show the following info message if defining ontology is not available (placed inside isSuccess span)?
+  /*{
+    !props.ontologyId && !descText && !response.inDefiningOntology && fixedEntityType !== "ontology" &&
+    <EuiFlexItem>
+      <EuiText>
+        <i>Defining ontology not available. Showing occurrence inside {response.ontology} instead.</i>
+      </EuiText>
+    </EuiFlexItem>
+  }*/
+
   return (
     <>
       {isLoading && <EuiLoadingSpinner size="s" />}
       {isSuccess &&
           <>
-            {
-                !props.ontologyId && !descText && !response.inDefiningOntology && fixedEntityType !== "ontology" &&
-                <EuiFlexItem>
-                  <EuiText>
-                    <i>Defining ontology not available. Showing occurrence inside {response.ontology} instead.</i>
-                  </EuiText>
-                </EuiFlexItem>
-            }
             <EuiText {...rest}>{descText || response.description}</EuiText>
           </>
       }

--- a/src/components/widgets/MetadataWidget/MetadataWidget.stories.tsx
+++ b/src/components/widgets/MetadataWidget/MetadataWidget.stories.tsx
@@ -64,3 +64,23 @@ MetadataWidget1.args = {  api: "https://semanticlookup.zbmed.de/api/",
   entityType: "term",
   parameter: "collection=nfdi4health"
 };
+
+export const SelectingDefiningOntology = Template.bind({});
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+SelectingDefiningOntology.args = {  api: "https://www.ebi.ac.uk/ols/api/",
+  iri: "http://purl.obolibrary.org/obo/IAO_0000631",
+  entityType: "term",
+  parameter: ""
+};
+
+export const DefiningOntologyUnavailable = Template.bind({});
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+DefiningOntologyUnavailable.args = {  api: "https://www.ebi.ac.uk/ols/api/",
+  iri: "http://identifiers.org/uniprot/Q9VAM9",
+  entityType: "term",
+  parameter: ""
+};

--- a/src/components/widgets/MetadataWidget/MetadataWidget.tsx
+++ b/src/components/widgets/MetadataWidget/MetadataWidget.tsx
@@ -1,14 +1,16 @@
 import React from "react";
-import { EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
+import {EuiFlexGroup, EuiFlexItem, EuiLoadingSpinner, EuiText} from "@elastic/eui";
 import { BreadcrumbWidget } from "./BreadcrumbWidget";
 import { IriWidget } from "./IriWidget";
 import { TitleWidget } from "./TitleWidget";
 import { DescriptionWidget } from "./DescriptionWidget";
 import { TabWidget } from "./TabWidget";
+import {useQuery} from "react-query";
+import {OlsApi} from "../../../api/OlsApi";
 
 export interface MetadataWidgetProps {
   iri: string;
-  ontologyId: string;
+  ontologyId?: string;
   api: string;
   entityType:
     | "term" | "class" //equivalent: API uses 'class', rest uses 'term' -> both allowed here
@@ -18,42 +20,111 @@ export interface MetadataWidgetProps {
   parameter?: string
 }
 
-function MetadataWidget(props: MetadataWidgetProps) {
-    const { iri, api, ontologyId, entityType, parameter } = props;
-  return (
-    <EuiFlexGroup direction="column" style={{ maxWidth: 600 }}>
-      <EuiFlexItem grow={false}>
-        <span>
-          <BreadcrumbWidget api={api} iri={iri} entityType={entityType} ontologyId={ontologyId} parameter={parameter}/>
-        </span>
-      </EuiFlexItem>
-      <EuiFlexItem>
-        <EuiFlexGroup direction="column">
-          <EuiFlexItem>
-            <EuiFlexGroup>
-              <EuiFlexItem grow={false}>
-                <IriWidget iri={iri} parameter={parameter}/>
-              </EuiFlexItem>
-            </EuiFlexGroup>
-          </EuiFlexItem>
+/**
+ * returns JSON of defining ontology or of first ontology if defining ontology is not found
+ */
+async function getPreferredOntologyJSON(olsApi: OlsApi, entityType: string, iri: string, parameter: string) {
+    if(entityType === "term" || entityType === "class") {
+        const response = await olsApi.getTerm(undefined, undefined, {termIri: iri}, parameter)
+            .catch((error) => console.log(error));
+        const definingOntologyArr = response["_embedded"]["terms"].filter((term: any) => {return term["is_defining_ontology"]});
+        if(definingOntologyArr.length > 0) return definingOntologyArr[0];
+        else return response["_embedded"]["terms"][0];
+    }
+    else if(entityType === "property") {
+        const response = await olsApi.getProperty(undefined, undefined, {propertyIri: iri}, parameter)
+            .catch((error) => console.log(error));
+        const definingOntologyArr = response["_embedded"]["terms"].filter((term: any) => {return term["is_defining_ontology"]});
+        if(definingOntologyArr.length > 0) return definingOntologyArr[0];
+        else return response["_embedded"]["terms"][0];
+    }
+    else if(entityType === "individual") {
+        const response = await olsApi.getIndividual(undefined, undefined, {individualIri: iri}, parameter)
+            .catch((error) => console.log(error));
+        const definingOntologyArr = response["_embedded"]["terms"].filter((term: any) => {return term["is_defining_ontology"]});
+        if(definingOntologyArr.length > 0) return definingOntologyArr[0];
+        else return response["_embedded"]["terms"][0];
+    }
+    else {
+        throw Error("Unexpected entity type. Should be one of: 'term', 'class', 'property', 'individual'");
+    }
+}
 
-          <EuiFlexItem grow={false}>
-            <TitleWidget iri={iri} api={api} ontologyId={ontologyId} entityType={entityType} parameter={parameter} />
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      </EuiFlexItem>
-      <EuiFlexItem>
-        <DescriptionWidget iri={iri} api={api} ontologyId={ontologyId} entityType={entityType} parameter={parameter}/>
-      </EuiFlexItem>
-      <EuiFlexItem>
-        <TabWidget
-          iri={iri}
-          ontologyId={ontologyId}
-          api={api}
-          parameter={parameter}
-         entityType={entityType}/>
-      </EuiFlexItem>
-    </EuiFlexGroup>
+function MetadataWidget(props: MetadataWidgetProps) {
+    const { iri, api, entityType, parameter } = props;
+
+    const olsApi = new OlsApi(api);
+
+    const {
+        data: ontologyJSON,
+        isLoading: isLoadingOntologyId,
+        isSuccess: isSuccessOntologyId,
+        isError: isErrorOntologyId,
+        error: errorOntologyId
+    } = useQuery(
+        [
+            "ontologyId",
+            iri,
+            api,
+            entityType,
+            parameter,
+            props.ontologyId
+        ],
+        async () => {
+            return getPreferredOntologyJSON(olsApi, entityType, iri, parameter || "");
+        },
+        {
+
+        }
+    )
+
+  return (
+      <>
+          {isLoadingOntologyId && <EuiLoadingSpinner size="s"></EuiLoadingSpinner>}
+          {(props.ontologyId || isSuccessOntologyId) &&
+              <EuiFlexGroup direction="column" style={{ maxWidth: 600 }}>
+                  {
+                      !props.ontologyId && !ontologyJSON["is_defining_ontology"] &&
+                      <EuiFlexItem>
+                          <EuiText color="danger">
+                              Defining ontology not available. Showing occurrence inside {ontologyJSON["ontology_name"]} instead.
+                          </EuiText>
+                      </EuiFlexItem>
+                  }
+                  <EuiFlexItem grow={false}>
+                <span>
+                  <BreadcrumbWidget api={api} iri={iri} entityType={entityType} ontologyId={props.ontologyId ? props.ontologyId : ontologyJSON["ontology_name"]} parameter={parameter}/>
+                </span>
+                  </EuiFlexItem>
+                  <EuiFlexItem>
+                      <EuiFlexGroup direction="column">
+                          <EuiFlexItem>
+                              <EuiFlexGroup>
+                                  <EuiFlexItem grow={false}>
+                                      <IriWidget iri={iri} parameter={parameter}/>
+                                  </EuiFlexItem>
+                              </EuiFlexGroup>
+                          </EuiFlexItem>
+
+                          <EuiFlexItem grow={false}>
+                              <TitleWidget iri={iri} api={api} ontologyId={props.ontologyId ? props.ontologyId : ontologyJSON["ontology_name"]} entityType={entityType} parameter={parameter} />
+                          </EuiFlexItem>
+                      </EuiFlexGroup>
+                  </EuiFlexItem>
+                  <EuiFlexItem>
+                      <DescriptionWidget iri={iri} api={api} ontologyId={props.ontologyId ? props.ontologyId : ontologyJSON["ontology_name"]} entityType={entityType} parameter={parameter}/>
+                  </EuiFlexItem>
+                  <EuiFlexItem>
+                      <TabWidget
+                          iri={iri}
+                          ontologyId={props.ontologyId ? props.ontologyId : ontologyJSON["ontology_name"]}
+                          api={api}
+                          parameter={parameter}
+                          entityType={entityType}/>
+                  </EuiFlexItem>
+              </EuiFlexGroup>
+          }
+      </>
   );
 }
 export { MetadataWidget };

--- a/src/components/widgets/MetadataWidget/TabWidget/AlternativeNameTabWidget/AlternativeNameTabWidget.stories.tsx
+++ b/src/components/widgets/MetadataWidget/TabWidget/AlternativeNameTabWidget/AlternativeNameTabWidget.stories.tsx
@@ -65,3 +65,24 @@ AlternativeNameTabWidget1.args = {
   entityType: "term",
   ontologyId: "ncit",
 };
+
+export const SelectingDefiningOntology = Template.bind({});
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+SelectingDefiningOntology.args = {  api: "https://www.ebi.ac.uk/ols/api/",
+  iri: "http://purl.obolibrary.org/obo/IAO_0000631",
+  entityType: "term",
+  parameter: ""
+};
+
+export const DefiningOntologyUnavailable = Template.bind({});
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+DefiningOntologyUnavailable.args = {  api: "https://www.ebi.ac.uk/ols/api/",
+  iri: "http://identifiers.org/uniprot/Q9VAM9",
+  entityType: "term",
+  parameter: ""
+};
+

--- a/src/components/widgets/MetadataWidget/TabWidget/AlternativeNameTabWidget/AlternativeNameTabWidget.tsx
+++ b/src/components/widgets/MetadataWidget/TabWidget/AlternativeNameTabWidget/AlternativeNameTabWidget.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import {EuiFlexGroup, EuiFlexItem, EuiLoadingSpinner, EuiPanel, EuiSpacer, EuiText} from "@elastic/eui";
+import {EuiFlexGroup, EuiFlexItem, EuiLoadingSpinner, EuiPanel, EuiText} from "@elastic/eui";
 import { OlsApi } from '../../../../../api/OlsApi'
 import { useQuery } from 'react-query'
 import {getPreferredOntologyJSON} from "../../index";
@@ -40,18 +40,20 @@ function AlternativeNameTabWidget(props: AlternativeNameTabWidgetProps) {
     return <EuiText>No alternative names exist.</EuiText>;
   }
 
+    // TODO: Should AlternativeNameTabWidget show the following info message if defining ontology is not available (placed inside EuiPanel span)?
+    /*{
+        isSuccess && !props.ontologyId && !ontologyJSON["is_defining_ontology"] &&
+        <EuiFlexItem>
+            <EuiText>
+                <i>Defining ontology not available. Showing occurrence inside {ontologyJSON["ontology_name"]} instead.</i>
+            </EuiText>
+            <EuiSpacer size={"s"}></EuiSpacer>
+        </EuiFlexItem>
+    }*/
+
   return (
     <EuiPanel>
       <>
-        {
-          isSuccess && !props.ontologyId && !ontologyJSON["is_defining_ontology"] &&
-          <EuiFlexItem>
-            <EuiText>
-              <i>Defining ontology not available. Showing occurrence inside {ontologyJSON["ontology_name"]} instead.</i>
-            </EuiText>
-            <EuiSpacer size={"s"}></EuiSpacer>
-          </EuiFlexItem>
-        }
         <EuiFlexGroup style={{ padding: 10 }} direction="column">
           {isSuccess && renderAltLabel()}
           {isLoading && <EuiLoadingSpinner></EuiLoadingSpinner>}

--- a/src/components/widgets/MetadataWidget/TabWidget/CrossRefWidget/CrossRefTabWidget.stories.tsx
+++ b/src/components/widgets/MetadataWidget/TabWidget/CrossRefWidget/CrossRefTabWidget.stories.tsx
@@ -58,5 +58,26 @@ CrossRefTabWidget1.args = {
   iri: "http://purl.obolibrary.org/obo/RXNO_0000138",
   api: "https://www.ebi.ac.uk/ols/api/",
   entityType: "term",
-  ontologyId: "rxno"
+  ontologyId: "rxno",
+  parameter: ""
+};
+
+export const SelectingDefiningOntology = Template.bind({});
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+SelectingDefiningOntology.args = {  api: "https://www.ebi.ac.uk/ols/api/",
+  iri: "http://purl.obolibrary.org/obo/IAO_0000631",
+  entityType: "term",
+  parameter: ""
+};
+
+export const DefiningOntologyUnavailable = Template.bind({});
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+DefiningOntologyUnavailable.args = {  api: "https://www.ebi.ac.uk/ols/api/",
+  iri: "http://identifiers.org/uniprot/Q9VAM9",
+  entityType: "term",
+  parameter: ""
 };

--- a/src/components/widgets/MetadataWidget/TabWidget/CrossRefWidget/CrossRefTabWidget.tsx
+++ b/src/components/widgets/MetadataWidget/TabWidget/CrossRefWidget/CrossRefTabWidget.tsx
@@ -3,7 +3,7 @@ import {
     EuiFlexGroup,
     EuiFlexItem,
     EuiLink, EuiLoadingSpinner,
-    EuiPanel, EuiSpacer,
+    EuiPanel,
     EuiText,
 } from "@elastic/eui";
 import { OlsApi } from '../../../../../api/OlsApi'
@@ -78,18 +78,20 @@ function CrossRefTabWidget(props: CrossRefWidgetProps) {
     return <EuiText>No cross references exist.</EuiText>;
   }
 
+    // TODO: Should CrossRefTabWidget show the following info message if defining ontology is not available (placed inside EuiPanel span)?
+    /*{
+        isSuccess && !props.ontologyId && !ontologyJSON["is_defining_ontology"] &&
+        <EuiFlexItem>
+            <EuiText>
+                <i>Defining ontology not available. Showing occurrence inside {ontologyJSON["ontology_name"]} instead.</i>
+            </EuiText>
+            <EuiSpacer size={"s"}></EuiSpacer>
+        </EuiFlexItem>
+    }*/
+
   return (
     <EuiPanel>
         <>
-            {
-                isSuccess && !props.ontologyId && !ontologyJSON["is_defining_ontology"] &&
-                <EuiFlexItem>
-                    <EuiText>
-                        <i>Defining ontology not available. Showing occurrence inside {ontologyJSON["ontology_name"]} instead.</i>
-                    </EuiText>
-                    <EuiSpacer size={"s"}></EuiSpacer>
-                </EuiFlexItem>
-            }
             <EuiFlexGroup style={{ padding: 7 }} direction="column">
                 {isSuccess && renderCrossRefs(getCrossRefs(ontologyJSON))}
                 {isLoading && <EuiLoadingSpinner/>}

--- a/src/components/widgets/MetadataWidget/TabWidget/CrossRefWidget/CrossRefTabWidget.tsx
+++ b/src/components/widgets/MetadataWidget/TabWidget/CrossRefWidget/CrossRefTabWidget.tsx
@@ -1,13 +1,14 @@
 import React from "react";
 import {
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiLink, EuiLoadingSpinner,
-  EuiPanel,
-  EuiText,
+    EuiFlexGroup,
+    EuiFlexItem,
+    EuiLink, EuiLoadingSpinner,
+    EuiPanel, EuiSpacer,
+    EuiText,
 } from "@elastic/eui";
 import { OlsApi } from '../../../../../api/OlsApi'
 import { useQuery } from 'react-query'
+import {getPreferredOntologyJSON} from "../../index";
 
 export interface CrossRefWidgetProps {
   iri: string;
@@ -22,43 +23,17 @@ export interface CrossRefWidgetProps {
   parameter?: string;
 }
 
-interface CrossRefs {
-    crossrefs: [{
-      database: string,
-      id: string,
-      url: string
-    }]
-}
-
-async function getCorssRefs(olsApi: OlsApi, entityType: string, iri?: string, ontologyId?: string, parameter?: string): Promise<CrossRefs> {
-    if (entityType == "term" || entityType == "class") {
-        const response = await olsApi.getTerm(undefined, undefined, {ontologyId: ontologyId, termIri: iri}, parameter)
-          .catch((error) => console.log(error));
+function getCrossRefs(response: any) {
+    if (response && response['obo_xref']) {
         return {
-            crossrefs: response._embedded.terms[0].obo_xref,
+            crossrefs: response['obo_xref'],
         };
     }
-    if (entityType == "property") {
-        const response = await olsApi.getProperty(undefined, undefined, {ontologyId: ontologyId, propertyIri: iri}, parameter)
-          .catch((error) => console.log(error));
+    else {
         return {
-            crossrefs: response._embedded.properties[0].obo_xref,
+            crossrefs : [],
         };
     }
-    if (entityType == "individual") {
-        const response = await olsApi.getIndividual(undefined, undefined, {ontologyId: ontologyId, individualIri: iri}, parameter)
-          .catch((error) => console.log(error));
-        return {
-            crossrefs: response._embedded.individuals[0].obo_xref,
-        };
-    }
-    return {
-       crossrefs : [{
-         database: "",
-         id: "",
-         url: ""
-       }],
-    };
 }
 
 function CrossRefTabWidget(props: CrossRefWidgetProps) {
@@ -66,15 +41,16 @@ function CrossRefTabWidget(props: CrossRefWidgetProps) {
   const olsApi = new OlsApi(api);
 
   const {
-        data,
+        data: ontologyJSON,
         isLoading,
         isSuccess,
         isError,
     } = useQuery([api, iri, ontologyId, entityType, parameter, "entityInfo"], () => {
-        return getCorssRefs(olsApi, entityType, iri, ontologyId);
+        return getPreferredOntologyJSON(olsApi, entityType, ontologyId, iri, parameter);
     });
 
-  function renderCrossRefs() {
+  function renderCrossRefs(data: any) {
+    console.dir(data.crossrefs)
     if (data?.crossrefs && data.crossrefs.length > 0) {
       return data?.crossrefs.map((item, index) => (
         <EuiFlexItem key={index}>
@@ -104,11 +80,22 @@ function CrossRefTabWidget(props: CrossRefWidgetProps) {
 
   return (
     <EuiPanel>
-      <EuiFlexGroup style={{ padding: 7 }} direction="column">
-        {isSuccess && renderCrossRefs()}
-        {isLoading && <EuiLoadingSpinner/>}
-        {isError && <EuiText>No cross references available.</EuiText>}
-      </EuiFlexGroup>
+        <>
+            {
+                isSuccess && !props.ontologyId && !ontologyJSON["is_defining_ontology"] &&
+                <EuiFlexItem>
+                    <EuiText>
+                        <i>Defining ontology not available. Showing occurrence inside {ontologyJSON["ontology_name"]} instead.</i>
+                    </EuiText>
+                    <EuiSpacer size={"s"}></EuiSpacer>
+                </EuiFlexItem>
+            }
+            <EuiFlexGroup style={{ padding: 7 }} direction="column">
+                {isSuccess && renderCrossRefs(getCrossRefs(ontologyJSON))}
+                {isLoading && <EuiLoadingSpinner/>}
+                {isError && <EuiText>No cross references available.</EuiText>}
+            </EuiFlexGroup>
+        </>
     </EuiPanel>
   );
 }

--- a/src/components/widgets/MetadataWidget/TabWidget/TabWidget.stories.tsx
+++ b/src/components/widgets/MetadataWidget/TabWidget/TabWidget.stories.tsx
@@ -59,3 +59,23 @@ TabWidget1.args = {
   iri: "http://purl.obolibrary.org/obo/NCIT_C2985",
   entityType: "term"
 };
+
+export const SelectingDefiningOntology = Template.bind({});
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+SelectingDefiningOntology.args = {  api: "https://www.ebi.ac.uk/ols/api/",
+  iri: "http://purl.obolibrary.org/obo/IAO_0000631",
+  entityType: "term",
+  parameter: ""
+};
+
+export const DefiningOntologyUnavailable = Template.bind({});
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+DefiningOntologyUnavailable.args = {  api: "https://www.ebi.ac.uk/ols/api/",
+  iri: "http://identifiers.org/uniprot/Q9VAM9",
+  entityType: "term",
+  parameter: ""
+};

--- a/src/components/widgets/MetadataWidget/TabWidget/TabWidget.tsx
+++ b/src/components/widgets/MetadataWidget/TabWidget/TabWidget.tsx
@@ -1,17 +1,19 @@
 import React from "react";
 import {
-  EuiFlexItem,
-  EuiTabbedContent,
-  EuiTabbedContentTab,
+  EuiFlexItem, EuiLoadingSpinner,
+  EuiTabbedContent, EuiText,
 } from "@elastic/eui";
 import { AlternativeNameTabWidget } from "./AlternativeNameTabWidget";
 import { CrossRefTabWidget } from "./CrossRefWidget";
 import { HierarchyWidget } from "./HierarchyWidget";
+import {useQuery} from "react-query";
+import {OlsApi} from "../../../../api/OlsApi";
+import {getPreferredOntologyJSON} from "../index";
 
 export interface TabWidgetProps {
   iri: string;
   api: string;
-  ontologyId: string;
+  ontologyId?: string;
   entityType:
       | "ontology"
       | "term" | "class" //equivalent: API uses 'class', rest uses 'term' -> both allowed here
@@ -23,42 +25,77 @@ export interface TabWidgetProps {
 
 function TabWidget(props: TabWidgetProps) {
   const { iri, api, ontologyId, entityType, parameter, ...rest } = props;
-  const tabs: Array<EuiTabbedContentTab> = [
-    {
-      content: <AlternativeNameTabWidget
-          api={api}
-          iri={iri}
-          ontologyId={ontologyId}
-          entityType={entityType}
-      />,
-      id: "tab1",
-      name: "Alternative Names",
-    },
-    {
-      content: (
-        <HierarchyWidget api={api} iri={iri} ontologyId={ontologyId} />
-      ),
-      id: "tab2",
-      name: "Hierarchy",
-    },
-    {
-      content: <CrossRefTabWidget
-          api={api}
-          iri={iri}
-          ontologyId={ontologyId}
-          entityType={entityType}
-      />,
-      id: "tab3",
-      name: "Cross references",
-    },
-  ];
+  const fixedEntityType = entityType == "class" ? "term" : entityType
+  const olsApi = new OlsApi(api);
+
+  const {
+    data: ontologyJSON,
+    isLoading: isLoading,
+    isSuccess: isSuccess,
+  } = useQuery(
+      [
+          api,
+          "tab-widget",
+          fixedEntityType,
+          ontologyId,
+          iri,
+          parameter
+      ],
+      () => { return getPreferredOntologyJSON(olsApi, fixedEntityType, ontologyId, iri, parameter); }
+  );
 
   return (
-    <div>
-      <EuiFlexItem>
-        <EuiTabbedContent size="s" tabs={tabs} />
-      </EuiFlexItem>
-    </div>
+      <>
+        {isLoading && <EuiLoadingSpinner size="s"></EuiLoadingSpinner>}
+        {isSuccess &&
+            <>
+              {
+                  !props.ontologyId && !ontologyJSON["is_defining_ontology"] &&
+                  <EuiFlexItem>
+                    <EuiText>
+                      <i>Defining ontology not available. Showing occurrence inside {ontologyJSON["ontology_name"]} instead.</i>
+                    </EuiText>
+                  </EuiFlexItem>
+              }
+              <div>
+                <EuiFlexItem>
+                  <EuiTabbedContent size="s" tabs={
+                    [
+                      {
+                        content: <AlternativeNameTabWidget
+                            api={api}
+                            iri={iri}
+                            ontologyId={ontologyJSON['ontology_name']}
+                            entityType={entityType}
+                        />,
+                        id: "tab1",
+                        name: "Alternative Names",
+                      },
+                      {
+                        content: (
+                            <HierarchyWidget api={api} iri={iri} ontologyId={ontologyJSON['ontology_name']} />
+                        ),
+                        id: "tab2",
+                        name: "Hierarchy",
+                      },
+                      {
+                        content: <CrossRefTabWidget
+                            api={api}
+                            iri={iri}
+                            ontologyId={ontologyJSON['ontology_name']}
+                            entityType={entityType}
+                        />,
+                        id: "tab3",
+                        name: "Cross references",
+                      },
+                    ]
+                  } />
+                </EuiFlexItem>
+              </div>
+            </>
+
+        }
+      </>
   );
 }
 

--- a/src/components/widgets/MetadataWidget/TitleWidget/TitleWidget.stories.tsx
+++ b/src/components/widgets/MetadataWidget/TitleWidget/TitleWidget.stories.tsx
@@ -71,3 +71,23 @@ TitleWidget1.args = {
     ontologyId: "ncit",
     entityType: "term",
 };
+
+export const SelectingDefiningOntology = Template.bind({});
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+SelectingDefiningOntology.args = {  api: "https://www.ebi.ac.uk/ols/api/",
+    iri: "http://purl.obolibrary.org/obo/IAO_0000631",
+    entityType: "term",
+    parameter: ""
+};
+
+export const DefiningOntologyUnavailable = Template.bind({});
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+DefiningOntologyUnavailable.args = {  api: "https://www.ebi.ac.uk/ols/api/",
+    iri: "http://identifiers.org/uniprot/Q9VAM9",
+    entityType: "term",
+    parameter: ""
+};

--- a/src/components/widgets/MetadataWidget/TitleWidget/TitleWidget.tsx
+++ b/src/components/widgets/MetadataWidget/TitleWidget/TitleWidget.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import {useQuery} from "react-query";
-import {EuiLoadingSpinner, EuiText} from "@elastic/eui";
+import {EuiFlexItem, EuiLoadingSpinner, EuiText} from "@elastic/eui";
 import {OlsApi} from "../../../../api/OlsApi";
+import {getPreferredOntologyJSON} from "../index";
 
 export interface TitleWidgetProps {
     iri?: string;
@@ -21,39 +22,45 @@ export interface TitleWidgetProps {
 const NO_TITLE = "No title available.";
 
 
-async function getTitle(olsApi: OlsApi, entityType: string, ontologyId?: string, iri?: string, parameter?: string, default_value?: string): Promise<string> {
-    if (entityType == "ontology") {
-        const response = await olsApi.getOntology(undefined, undefined, {
-            ontologyId: ontologyId
-        }, parameter)
-            .catch((error) => console.log(error));
-        return response?.config.title || default_value || NO_TITLE
+async function getTitle(olsApi: OlsApi, entityType: string, ontologyId?: string, iri?: string, parameter?: string, default_value?: string): Promise<any> {
+    if (entityType === "ontology") {
+        if(!ontologyId) {
+            console.error(Error("ontology id has to be provided"))
+            return {
+                title: default_value || NO_TITLE
+            }
+        }
+        else {
+            const response = await olsApi.getOntology(undefined, undefined, {
+                ontologyId: ontologyId
+            }, parameter)
+                .catch((error) => console.log(error));
+            return {
+                title: response?.config.title || default_value || NO_TITLE
+            }
+        }
     }
-    if (entityType == "term") {
-        const response = await olsApi.getTerm(undefined, undefined, {
-            ontologyId: ontologyId,
-            termIri: iri
-        }, parameter)
-            .catch((error) => console.log(error));
-        return response?._embedded?.terms[0].label ||  default_value || NO_TITLE
+    if (entityType === "term" || entityType === "property" || entityType === "individual") {
+        if(!iri) {
+            console.error(Error("iri has to be provided"))
+            return {
+                title: default_value || NO_TITLE
+            }
+        }
+        else {
+            const response = await getPreferredOntologyJSON(olsApi, entityType, ontologyId, iri, parameter)
+            return {
+                title: response['label'] || default_value || NO_TITLE,
+                inDefiningOntology: response['is_defining_ontology'],
+                ontology: response['ontology_name']
+            }
+        }
     }
-    if (entityType == "property") {
-        const response = await olsApi.getProperty(undefined, undefined, {
-            ontologyId: ontologyId,
-            propertyIri: iri
-        }, parameter)
-            .catch((error) => console.log(error));
-        return response?._embedded?.properties[0].label ||  default_value || NO_TITLE
+    //unacceptable object type
+    console.error(Error("Unexpected entity type. Should be one of 'ontology', 'term', 'class', 'individual', 'property'"));
+    return {
+         title: default_value || NO_TITLE
     }
-    if (entityType == "individual") {
-        const response = await olsApi.getIndividual(undefined, undefined, {
-            ontologyId: ontologyId,
-            individualIri: iri
-        }, parameter)
-            .catch((error) => console.log(error));
-        return response?._embedded?.individuals[0].label ||  default_value || NO_TITLE
-    }
-    return  default_value || NO_TITLE;
 }
 
 function TitleWidget(props: TitleWidgetProps) {
@@ -62,15 +69,31 @@ function TitleWidget(props: TitleWidgetProps) {
     const olsApi = new OlsApi(api);
 
     const {
-        data: label,
+        data: response,
         isLoading,
+        isSuccess,
+        isError,
+        error,
     } = useQuery([api, "getTitle", fixedEntityType, ontologyId, iri, parameter], () => {
         return getTitle(olsApi, fixedEntityType, ontologyId, iri, parameter, default_value);
     });
 
     return (
         <>
-            {isLoading ? <EuiLoadingSpinner size="s"/> : <EuiText>{titleText || label}</EuiText>}
+            {isLoading && <EuiLoadingSpinner size="s"/>}
+            {isSuccess &&
+                <>
+                    {
+                        !props.ontologyId && !titleText && !response.inDefiningOntology && fixedEntityType !== "ontology" &&
+                        <EuiFlexItem>
+                            <EuiText>
+                                <i>Defining ontology not available. Showing occurrence inside {response.ontology} instead.</i>
+                            </EuiText>
+                        </EuiFlexItem>
+                    }
+                    <EuiText>{titleText || response.title}</EuiText>
+                </>}
+            {isError && <EuiText>{NO_TITLE}</EuiText>}
         </>
     );
 }

--- a/src/components/widgets/MetadataWidget/TitleWidget/TitleWidget.tsx
+++ b/src/components/widgets/MetadataWidget/TitleWidget/TitleWidget.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import {useQuery} from "react-query";
-import {EuiFlexItem, EuiLoadingSpinner, EuiText} from "@elastic/eui";
+import {EuiLoadingSpinner, EuiText} from "@elastic/eui";
 import {OlsApi} from "../../../../api/OlsApi";
 import {getPreferredOntologyJSON} from "../index";
 
@@ -78,19 +78,21 @@ function TitleWidget(props: TitleWidgetProps) {
         return getTitle(olsApi, fixedEntityType, ontologyId, iri, parameter, default_value);
     });
 
+    // TODO: Should TitleWidget show the following info message if defining ontology is not available (placed inside isSuccess span)?
+    /*{
+        !props.ontologyId && !titleText && !response.inDefiningOntology && fixedEntityType !== "ontology" &&
+        <EuiFlexItem>
+            <EuiText>
+                <i>Defining ontology not available. Showing occurrence inside {response.ontology} instead.</i>
+            </EuiText>
+        </EuiFlexItem>
+    }*/
+
     return (
         <>
             {isLoading && <EuiLoadingSpinner size="s"/>}
             {isSuccess &&
                 <>
-                    {
-                        !props.ontologyId && !titleText && !response.inDefiningOntology && fixedEntityType !== "ontology" &&
-                        <EuiFlexItem>
-                            <EuiText>
-                                <i>Defining ontology not available. Showing occurrence inside {response.ontology} instead.</i>
-                            </EuiText>
-                        </EuiFlexItem>
-                    }
                     <EuiText>{titleText || response.title}</EuiText>
                 </>}
             {isError && <EuiText>{NO_TITLE}</EuiText>}

--- a/src/components/widgets/MetadataWidget/index.ts
+++ b/src/components/widgets/MetadataWidget/index.ts
@@ -27,6 +27,7 @@ export async function getPreferredOntologyJSON(olsApi: OlsApi, entityType: strin
     }
     else {
         console.error(Error("Unexpected entity type. Should be one of: 'term', 'class', 'property', 'individual'"));
+        return undefined;
     }
 }
 

--- a/src/components/widgets/MetadataWidget/index.ts
+++ b/src/components/widgets/MetadataWidget/index.ts
@@ -1,3 +1,35 @@
+import {OlsApi} from "../../../api/OlsApi";
+
+/**
+ * returns JSON of defining ontology or of first ontology if defining ontology is not found
+ */
+export async function getPreferredOntologyJSON(olsApi: OlsApi, entityType: string, ontologyId: string | undefined, iri: string, parameter: string | undefined) {
+    if(entityType === "term" || entityType === "class") {
+        const response = await olsApi.getTerm(undefined, undefined, {ontologyId: ontologyId, termIri: iri}, parameter)
+            .catch((error) => console.log(error));
+        const definingOntologyArr = response["_embedded"]["terms"].filter((term: any) => {return term["is_defining_ontology"]});
+        if(definingOntologyArr.length > 0) return definingOntologyArr[0];
+        else return response["_embedded"]["terms"][0];
+    }
+    else if(entityType === "property") {
+        const response = await olsApi.getProperty(undefined, undefined, {ontologyId: ontologyId, propertyIri: iri}, parameter)
+            .catch((error) => console.log(error));
+        const definingOntologyArr = response["_embedded"]["properties"].filter((term: any) => {return term["is_defining_ontology"]});
+        if(definingOntologyArr.length > 0) return definingOntologyArr[0];
+        else return response["_embedded"]["properties"][0];
+    }
+    else if(entityType === "individual") {
+        const response = await olsApi.getIndividual(undefined, undefined, {ontologyId: ontologyId, individualIri: iri}, parameter)
+            .catch((error) => console.log(error));
+        const definingOntologyArr = response["_embedded"]["individuals"].filter((term: any) => {return term["is_defining_ontology"]});
+        if(definingOntologyArr.length > 0) return definingOntologyArr[0];
+        else return response["_embedded"]["individuals"][0];
+    }
+    else {
+        console.error(Error("Unexpected entity type. Should be one of: 'term', 'class', 'property', 'individual'"));
+    }
+}
+
 export * from "./DescriptionWidget";
 export * from "./IriWidget";
 export * from "./BreadcrumbWidget";

--- a/src/components/widgets/MetadataWidget/index.ts
+++ b/src/components/widgets/MetadataWidget/index.ts
@@ -1,7 +1,7 @@
 import {OlsApi} from "../../../api/OlsApi";
 
 /**
- * returns JSON of defining ontology or of first ontology if defining ontology is not found
+ * returns JSON of specified ontology or, if not provided, of defining ontology or of first ontology if defining ontology is not found
  */
 export async function getPreferredOntologyJSON(olsApi: OlsApi, entityType: string, ontologyId: string | undefined, iri: string, parameter: string | undefined) {
     if(entityType === "term" || entityType === "class") {


### PR DESCRIPTION
Made ontology id optional for Metadata- and child widgets. Whenever no ontologyId is provided, the defining ontology is selected, or, if not available, the first other available ontology. In this case, info messages are shown on the widgets, but are left out for AlternativeNameTabWidget, CrossRefTabWidget, TitleWidget and DescriptionWidget for now as the data should be independent from the ontology there (however, it practically isn't exactly identical)