### PR TITLE
merge(entity-relations-widget): first merge, still TODOS in EntityRelationsWidget

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nfdi4health/semlookp-widgets",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "This project includes a widget component library derived from the semantic lookup service SemLookP. The Terminology Service is a repository for biomedical resources that aims to provide a single point of access to the latest ontology and terminology versions. User interface (UI) functionalities were extracted and implemented as separate widgets to allow integration into other 3rd party services, thus simplifying the development of user interfaces and the visualization of semantic information. The widgets are built with React and TypeScript and can be used in React applications. SemLookP and the widgets are based on the Ontology Lookup Service (OLS), software developed by EBI.",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",

--- a/src/api/OlsApi.ts
+++ b/src/api/OlsApi.ts
@@ -171,6 +171,11 @@ export class OlsApi {
     return (await this.axiosInstance.get(queryPrefix+"terms", { params: {iri: contentParams?.termIri, parameter: this.buildOtherParams(parameter)} })).data;
   }
 
+  public getClass: apiCallFn = async (paginationParams, sortingParams, contentParams, parameter) => {
+    const queryPrefix = contentParams?.ontologyId ? "ontologies/"+contentParams?.ontologyId+"/" : ""
+    return (await this.axiosInstance.get(queryPrefix+"classes", { params: {iri: contentParams?.termIri, parameter: this.buildOtherParams(parameter)} })).data;
+  }
+
   public getProperty: apiCallFn = async (paginationParams, sortingParams, contentParams, parameter) => {
     const queryPrefix = contentParams?.ontologyId ? "ontologies/"+contentParams?.ontologyId+"/" : ""
     return (await this.axiosInstance.get(queryPrefix+"properties", { params: {iri: contentParams?.propertyIri, parameter: this.buildOtherParams(parameter)} })).data;

--- a/src/api/OlsApi.ts
+++ b/src/api/OlsApi.ts
@@ -160,27 +160,44 @@ export class OlsApi {
   }
 
   /**
-   * getTerm, getProperty, getIndividual:
-   * These methods always require the respective object IRI in contentParams to be set
+   * Is used to fetch a term from the api in ols3 (for ols4, getClass is used).
+   * Always requires the respective object IRI in contentParams to be set
    * If ontologyId is undefined in contentParams, the object will be queried from all ontologies, containing a list of results
    * If an ontologyId is provided in contentParams, the returned list will only contain the object from that specific ontology
    */
-
   public getTerm: apiCallFn = async (paginationParams, sortingParams, contentParams, parameter) => {
     const queryPrefix = contentParams?.ontologyId ? "ontologies/"+contentParams?.ontologyId+"/" : ""
     return (await this.axiosInstance.get(queryPrefix+"terms", { params: {iri: contentParams?.termIri, parameter: this.buildOtherParams(parameter)} })).data;
   }
 
+  /**
+   * Is used to fetch a class from the api in ols4 (for ols3, getTerm is used).
+   * Always requires the respective object IRI in contentParams to be set
+   * If ontologyId is undefined in contentParams, the object will be queried from all ontologies, containing a list of results
+   * If an ontologyId is provided in contentParams, the returned list will only contain the object from that specific ontology
+   */
   public getClass: apiCallFn = async (paginationParams, sortingParams, contentParams, parameter) => {
     const queryPrefix = contentParams?.ontologyId ? "ontologies/"+contentParams?.ontologyId+"/" : ""
     return (await this.axiosInstance.get(queryPrefix+"classes", { params: {iri: contentParams?.termIri, parameter: this.buildOtherParams(parameter)} })).data;
   }
 
+  /**
+   * Is used to fetch a property from the api in ols3.
+   * Always requires the respective object IRI in contentParams to be set
+   * If ontologyId is undefined in contentParams, the object will be queried from all ontologies, containing a list of results
+   * If an ontologyId is provided in contentParams, the returned list will only contain the object from that specific ontology
+   */
   public getProperty: apiCallFn = async (paginationParams, sortingParams, contentParams, parameter) => {
     const queryPrefix = contentParams?.ontologyId ? "ontologies/"+contentParams?.ontologyId+"/" : ""
     return (await this.axiosInstance.get(queryPrefix+"properties", { params: {iri: contentParams?.propertyIri, parameter: this.buildOtherParams(parameter)} })).data;
   }
 
+  /**
+   * Is used to fetch an individual from the api in ols3.
+   * Always requires the respective object IRI in contentParams to be set
+   * If ontologyId is undefined in contentParams, the object will be queried from all ontologies, containing a list of results
+   * If an ontologyId is provided in contentParams, the returned list will only contain the object from that specific ontology
+   */
   public getIndividual: apiCallFn = async (paginationParams, sortingParams, contentParams, parameter) => {
     const queryPrefix = contentParams?.ontologyId ? "ontologies/"+contentParams?.ontologyId+"/" : ""
     return (await this.axiosInstance.get(queryPrefix+"individuals", { params: {iri: contentParams?.individualIri, parameter: this.buildOtherParams(parameter)} })).data;

--- a/src/api/OlsApi.ts
+++ b/src/api/OlsApi.ts
@@ -193,6 +193,17 @@ export class OlsApi {
   }
 
   /**
+   * Is used to fetch a classes instances from the api.
+   * Always requires the respective object IRI in contentParams to be set
+   * If ontologyId is undefined in contentParams, the object will be queried from all ontologies, containing a list of results
+   * If an ontologyId is provided in contentParams, the returned list will only contain the object from that specific ontology
+   */
+  public getClassInstances: apiCallFn = async (paginationParams, sortingParams, contentParams, parameter) => {
+    const queryPrefix = contentParams?.ontologyId ? "ontologies/"+contentParams?.ontologyId+"/" : ""
+    return (await this.axiosInstance.get(queryPrefix+"classes/"+contentParams?.termIri+"/instances", { params: { parameter: this.buildOtherParams(parameter)} })).data;
+  }
+
+  /**
    * Is used to fetch a property from the api in ols3.
    * Always requires the respective object IRI in contentParams to be set
    * If ontologyId is undefined in contentParams, the object will be queried from all ontologies, containing a list of results

--- a/src/api/OlsApi.ts
+++ b/src/api/OlsApi.ts
@@ -160,6 +160,17 @@ export class OlsApi {
   }
 
   /**
+   * Is used to fetch an entity from the api in ols4 (for ols3, getTerm, getProperty and getIndividual are used respectively).
+   * Always requires the respective object IRI in contentParams to be set
+   * If ontologyId is undefined in contentParams, the object will be queried from all ontologies, containing a list of results
+   * If an ontologyId is provided in contentParams, the returned list will only contain the object from that specific ontology
+   */
+  public getEntity: apiCallFn = async (paginationParams, sortingParams, contentParams, parameter) => {
+    const queryPrefix = contentParams?.ontologyId ? "ontologies/"+contentParams?.ontologyId+"/" : ""
+    return (await this.axiosInstance.get(queryPrefix+"entities", { params: {iri: contentParams?.termIri, parameter: this.buildOtherParams(parameter)} })).data;
+  }
+
+  /**
    * Is used to fetch a term from the api in ols3 (for ols4, getClass is used).
    * Always requires the respective object IRI in contentParams to be set
    * If ontologyId is undefined in contentParams, the object will be queried from all ontologies, containing a list of results

--- a/src/components/widgets/EntityRelationsWidget/EntityRelationsWidget.stories.tsx
+++ b/src/components/widgets/EntityRelationsWidget/EntityRelationsWidget.stories.tsx
@@ -45,10 +45,21 @@ export default {
         },
         ontologyId: {
             type: { required: false }
+        },
+        showBadges: {
+            description: "Enable / disable showing badges for defining ontologies.",
+            control: {
+                type: "radio",
+            },
+            options: [
+                true,
+                false
+            ],
         }
     },
     args: {
         hasTitle: true,
+        showBadges: true,
     }
 };
 
@@ -134,4 +145,14 @@ Instances.args = {
     entityType: "term",
     ontologyId: "iao",
     iri: "http://purl.obolibrary.org/obo/IAO_0000078",
+};
+
+export const Axioms = Template.bind({});
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+Axioms.args = {
+    api: "https://www.ebi.ac.uk/ols4/api/v2",
+    entityType: "term",
+    ontologyId: "aism",
+    iri: "http://purl.obolibrary.org/obo/UBERON_0000006",
 };

--- a/src/components/widgets/EntityRelationsWidget/EntityRelationsWidget.stories.tsx
+++ b/src/components/widgets/EntityRelationsWidget/EntityRelationsWidget.stories.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { EntityRelationsWidget, EntityRelationsWidgetProps } from "./EntityRelationsWidget";
+
+export default {
+    title: "EntityRelationsWidget",
+    component: EntityRelationsWidget,
+    parameters: {
+        layout: "centered",
+    },
+    argTypes: {
+        api: {
+            description: "Instance of the OLS API to call.",
+            control: {
+                type: "radio",
+            },
+            options: [
+                "https://www.ebi.ac.uk/ols4/api/v2",
+                "https://semanticlookup.zbmed.de/ols/api/",
+                "https://semanticlookup.zbmed.de/api/",
+            ],
+        },
+        hasTitle: {
+            description: "Show title, default is true",
+            type: { required: false },
+        },
+        entityType: {
+            description: "Sets the type of the entity whose information you want to fetch. Accepts 'term', 'class', 'property', or 'individual'.",
+            control: {
+                type: "radio",
+            },
+            options: [
+                "ontology",
+                "term",
+                "class",
+                "property",
+                "individual",
+                "INVALID STRING"
+            ],
+        },
+        iri: {
+            description: "Entity IRI whose information you want to fetch.",
+        },
+        parameter: {
+            type: { required: false }
+        },
+        ontologyId: {
+            type: { required: false }
+        }
+    },
+    args: {
+        hasTitle: true,
+    }
+};
+
+const Template = (args: EntityRelationsWidgetProps) => (
+    <EntityRelationsWidget {...args} />
+);
+
+export const SubEntityOf = Template.bind({});
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+SubEntityOf.args = {
+    api: "https://www.ebi.ac.uk/ols4/api/v2",
+    entityType: "term",
+    ontologyId: "go",
+    iri: "http://purl.obolibrary.org/obo/GO_0051296",
+};
+
+export const DifferentFrom = Template.bind({});
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+DifferentFrom.args = {
+    api: "https://www.ebi.ac.uk/ols4/api/v2",
+    entityType: "individual",
+    ontologyId: "bco",
+    iri: "http://purl.obolibrary.org/obo/IAO_0000120",
+};

--- a/src/components/widgets/EntityRelationsWidget/EntityRelationsWidget.stories.tsx
+++ b/src/components/widgets/EntityRelationsWidget/EntityRelationsWidget.stories.tsx
@@ -14,10 +14,10 @@ export default {
                 type: "radio",
             },
             options: [
-                "https://www.ebi.ac.uk/ols4/api/v2",
+                "https://www.ebi.ac.uk/ols4/api/",
                 "https://semanticlookup.zbmed.de/ols/api/",
                 "https://semanticlookup.zbmed.de/api/",
-                "http://ols4.qa.km.k8s.zbmed.de/ols4/api/v2/"
+                "http://ols4.qa.km.k8s.zbmed.de/ols4/api/"
             ],
         },
         hasTitle: {
@@ -72,7 +72,7 @@ export const SubEntityOf = Template.bind({});
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 SubEntityOf.args = {
-    api: "https://www.ebi.ac.uk/ols4/api/v2",
+    api: "https://www.ebi.ac.uk/ols4/api/",
     entityType: "term",
     ontologyId: "agro",
     iri: "http://purl.obolibrary.org/obo/AGRO_00000002",
@@ -82,7 +82,7 @@ export const AllValuesFrom = Template.bind({});
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 AllValuesFrom.args = {
-    api: "https://www.ebi.ac.uk/ols4/api/v2",
+    api: "https://www.ebi.ac.uk/ols4/api/",
     entityType: "term",
     ontologyId: "go",
     iri: "http://purl.obolibrary.org/obo/BFO_0000004",
@@ -92,7 +92,7 @@ export const DifferentFrom = Template.bind({});
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 DifferentFrom.args = {
-    api: "https://www.ebi.ac.uk/ols4/api/v2",
+    api: "https://www.ebi.ac.uk/ols4/api/",
     entityType: "individual",
     ontologyId: "bco",
     iri: "http://purl.obolibrary.org/obo/IAO_0000120",
@@ -102,7 +102,7 @@ export const EquivalentTo = Template.bind({});
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 EquivalentTo.args = {
-    api: "https://www.ebi.ac.uk/ols4/api/v2",
+    api: "https://www.ebi.ac.uk/ols4/api/",
     entityType: "term",
     ontologyId: "go",
     iri: "http://purl.obolibrary.org/obo/GO_0048021",
@@ -112,7 +112,7 @@ export const SingleValue = Template.bind({});
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 SingleValue.args = {
-    api: "https://www.ebi.ac.uk/ols4/api/v2",
+    api: "https://www.ebi.ac.uk/ols4/api/",
     entityType: "term",
     ontologyId: "bfo",
     iri: "http://purl.obolibrary.org/obo/BFO_0000001",
@@ -122,7 +122,7 @@ export const InverseOf = Template.bind({});
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 InverseOf.args = {
-    api: "https://www.ebi.ac.uk/ols4/api/v2",
+    api: "https://www.ebi.ac.uk/ols4/api/",
     entityType: "property",
     ontologyId: "ro",
     iri: "http://purl.obolibrary.org/obo/RO_0000057",
@@ -132,7 +132,7 @@ export const PropertyChain = Template.bind({});
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 PropertyChain.args = {
-    api: "https://www.ebi.ac.uk/ols4/api/v2",
+    api: "https://www.ebi.ac.uk/ols4/api/",
     entityType: "property",
     ontologyId: "ro",
     iri: "http://purl.obolibrary.org/obo/RO_0002170",
@@ -142,7 +142,7 @@ export const Instances = Template.bind({});
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 Instances.args = {
-    api: "https://www.ebi.ac.uk/ols4/api/v2",
+    api: "https://www.ebi.ac.uk/ols4/api/",
     entityType: "term",
     ontologyId: "iao",
     iri: "http://purl.obolibrary.org/obo/IAO_0000078",
@@ -152,7 +152,7 @@ export const Axioms = Template.bind({});
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 Axioms.args = {
-    api: "https://www.ebi.ac.uk/ols4/api/v2",
+    api: "https://www.ebi.ac.uk/ols4/api/",
     entityType: "term",
     ontologyId: "aism",
     iri: "http://purl.obolibrary.org/obo/UBERON_0000006",
@@ -162,7 +162,7 @@ export const QualifiedCardinality = Template.bind({});
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 QualifiedCardinality.args = {
-    api: "https://www.ebi.ac.uk/ols4/api/v2",
+    api: "https://www.ebi.ac.uk/ols4/api/",
     entityType: "term",
     ontologyId: "foodon",
     iri: "http://purl.obolibrary.org/obo/FOODON_00003382",

--- a/src/components/widgets/EntityRelationsWidget/EntityRelationsWidget.stories.tsx
+++ b/src/components/widgets/EntityRelationsWidget/EntityRelationsWidget.stories.tsx
@@ -62,8 +62,8 @@ export const SubEntityOf = Template.bind({});
 SubEntityOf.args = {
     api: "https://www.ebi.ac.uk/ols4/api/v2",
     entityType: "term",
-    ontologyId: "go",
-    iri: "http://purl.obolibrary.org/obo/GO_0051296",
+    ontologyId: "agro",
+    iri: "http://purl.obolibrary.org/obo/AGRO_00000002",
 };
 
 export const DifferentFrom = Template.bind({});

--- a/src/components/widgets/EntityRelationsWidget/EntityRelationsWidget.stories.tsx
+++ b/src/components/widgets/EntityRelationsWidget/EntityRelationsWidget.stories.tsx
@@ -95,3 +95,13 @@ EquivalentTo.args = {
     ontologyId: "go",
     iri: "http://purl.obolibrary.org/obo/GO_0048021",
 };
+
+export const SingleValue = Template.bind({});
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+SingleValue.args = {
+    api: "https://www.ebi.ac.uk/ols4/api/v2",
+    entityType: "term",
+    ontologyId: "bfo",
+    iri: "http://purl.obolibrary.org/obo/BFO_0000001",
+};

--- a/src/components/widgets/EntityRelationsWidget/EntityRelationsWidget.stories.tsx
+++ b/src/components/widgets/EntityRelationsWidget/EntityRelationsWidget.stories.tsx
@@ -85,3 +85,13 @@ DifferentFrom.args = {
     ontologyId: "bco",
     iri: "http://purl.obolibrary.org/obo/IAO_0000120",
 };
+
+export const EquivalentTo = Template.bind({});
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+EquivalentTo.args = {
+    api: "https://www.ebi.ac.uk/ols4/api/v2",
+    entityType: "term",
+    ontologyId: "go",
+    iri: "http://purl.obolibrary.org/obo/GO_0048021",
+};

--- a/src/components/widgets/EntityRelationsWidget/EntityRelationsWidget.stories.tsx
+++ b/src/components/widgets/EntityRelationsWidget/EntityRelationsWidget.stories.tsx
@@ -132,6 +132,6 @@ export const Instances = Template.bind({});
 Instances.args = {
     api: "https://www.ebi.ac.uk/ols4/api/v2",
     entityType: "term",
-    ontologyId: "apollo_sv",
-    iri: "http://purl.obolibrary.org/obo/APOLLO_SV_00000107",
+    ontologyId: "iao",
+    iri: "http://purl.obolibrary.org/obo/IAO_0000078",
 };

--- a/src/components/widgets/EntityRelationsWidget/EntityRelationsWidget.stories.tsx
+++ b/src/components/widgets/EntityRelationsWidget/EntityRelationsWidget.stories.tsx
@@ -17,6 +17,7 @@ export default {
                 "https://www.ebi.ac.uk/ols4/api/v2",
                 "https://semanticlookup.zbmed.de/ols/api/",
                 "https://semanticlookup.zbmed.de/api/",
+                "http://ols4.qa.km.k8s.zbmed.de/ols4/api/v2/"
             ],
         },
         hasTitle: {
@@ -155,4 +156,14 @@ Axioms.args = {
     entityType: "term",
     ontologyId: "aism",
     iri: "http://purl.obolibrary.org/obo/UBERON_0000006",
+};
+
+export const QualifiedCardinality = Template.bind({});
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+QualifiedCardinality.args = {
+    api: "https://www.ebi.ac.uk/ols4/api/v2",
+    entityType: "term",
+    ontologyId: "foodon",
+    iri: "http://purl.obolibrary.org/obo/FOODON_00003382",
 };

--- a/src/components/widgets/EntityRelationsWidget/EntityRelationsWidget.stories.tsx
+++ b/src/components/widgets/EntityRelationsWidget/EntityRelationsWidget.stories.tsx
@@ -105,3 +105,33 @@ SingleValue.args = {
     ontologyId: "bfo",
     iri: "http://purl.obolibrary.org/obo/BFO_0000001",
 };
+
+export const InverseOf = Template.bind({});
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+InverseOf.args = {
+    api: "https://www.ebi.ac.uk/ols4/api/v2",
+    entityType: "property",
+    ontologyId: "ro",
+    iri: "http://purl.obolibrary.org/obo/RO_0000057",
+};
+
+export const PropertyChain = Template.bind({});
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+PropertyChain.args = {
+    api: "https://www.ebi.ac.uk/ols4/api/v2",
+    entityType: "property",
+    ontologyId: "ro",
+    iri: "http://purl.obolibrary.org/obo/RO_0002170",
+};
+
+export const Instances = Template.bind({});
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+Instances.args = {
+    api: "https://www.ebi.ac.uk/ols4/api/v2",
+    entityType: "term",
+    ontologyId: "apollo_sv",
+    iri: "http://purl.obolibrary.org/obo/APOLLO_SV_00000107",
+};

--- a/src/components/widgets/EntityRelationsWidget/EntityRelationsWidget.stories.tsx
+++ b/src/components/widgets/EntityRelationsWidget/EntityRelationsWidget.stories.tsx
@@ -66,6 +66,16 @@ SubEntityOf.args = {
     iri: "http://purl.obolibrary.org/obo/AGRO_00000002",
 };
 
+export const AllValuesFrom = Template.bind({});
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+AllValuesFrom.args = {
+    api: "https://www.ebi.ac.uk/ols4/api/v2",
+    entityType: "term",
+    ontologyId: "go",
+    iri: "http://purl.obolibrary.org/obo/BFO_0000004",
+};
+
 export const DifferentFrom = Template.bind({});
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore

--- a/src/components/widgets/EntityRelationsWidget/EntityRelationsWidget.tsx
+++ b/src/components/widgets/EntityRelationsWidget/EntityRelationsWidget.tsx
@@ -360,7 +360,7 @@ function getRelatedFrom(response: any, props: EntityRelationsWidgetProps) {
 
 function getTypes(response: any, props: EntityRelationsWidgetProps) {
     if(response && props.entityType === "individual" && response["http://www.w3.org/1999/02/22-rdf-syntax-ns#type"] !== undefined) {
-        const types = asArray(response["http://www.w3.org/1999/02/22-rdf-syntax-ns#type"]).filter((elem: any) => elem !== "http://www.w3.org/2002/07/owl#NamedIndividual" && elem !== "http://www.w3.org/2002/07/owl#Thing" && (!(typeof elem === "string") || !elem.startsWith("http://www.w3.org/2000/01/rdf-schema#")));
+        const types = asArray(response["http://www.w3.org/1999/02/22-rdf-syntax-ns#type"]).filter((elem: any) => elem !== "http://www.w3.org/2002/07/owl#NamedIndividual" && (!(typeof elem === "string") || !elem.startsWith("http://www.w3.org/2000/01/rdf-schema#")));
 
         return (<EuiFlexItem>
             {

--- a/src/components/widgets/EntityRelationsWidget/EntityRelationsWidget.tsx
+++ b/src/components/widgets/EntityRelationsWidget/EntityRelationsWidget.tsx
@@ -3,7 +3,6 @@ import { OlsApi } from "../../../api/OlsApi";
 import { useQuery } from "react-query";
 import {EuiCard, EuiFlexItem, EuiLoadingSpinner, EuiText} from "@elastic/eui";
 import {ReactJSXElement} from "@emotion/react/types/jsx-namespace";
-import {eq} from "@elastic/eui/src/components/search_bar/query/operators";
 
 export interface EntityRelationsWidgetProps {
     api: string;
@@ -28,8 +27,12 @@ function getEntityTypeName(type: string) : string {
     return type === "term" ? "class" : type;
 }
 
-function getLabel(response: any, iri: string) : string {
-    return asArray(response["linkedEntities"][iri]["label"])[0];
+function getLabel(response: any, iri: string) : string | undefined {
+    if(response["linkedEntities"][iri]) {
+        return asArray(response["linkedEntities"][iri]["label"])[0];
+    }
+    else return undefined;
+
 }
 
 function asArray(obj: any) {
@@ -42,7 +45,7 @@ function randomString() {
     return (Math.random() * Math.pow(2, 54)).toString(36);
 }
 
-function getEntityLink(response: any, iri: string, props: EntityRelationsWidgetProps) {
+function getEntityLink(response: any, iri: string) {
     // reference to self; just display label because we are already on that page
     if (iri === response["iri"]) {
         return <b>{response["label"]}</b>
@@ -67,10 +70,10 @@ function getEntityLink(response: any, iri: string, props: EntityRelationsWidgetP
 
 function getSectionListElement(response: any, currentResponsePath: any, props: EntityRelationsWidgetProps): ReactJSXElement | undefined {
     if (typeof currentResponsePath === "string") {
-        return getEntityLink(response, currentResponsePath, props);
+        return getEntityLink(response, currentResponsePath);
     }
     else if (typeof currentResponsePath === "object" && currentResponsePath["value"]) { // TODO: Concat with else part? See relatedFrom (Manchester syntax does not get displayed, but neither in ols4)
-        return getEntityLink(response, currentResponsePath["value"], props);
+        return getEntityLink(response, currentResponsePath["value"]);
     }
     else { // type === "object"
         const someValuesFrom = currentResponsePath["http://www.w3.org/2002/07/owl#someValuesFrom"];

--- a/src/components/widgets/EntityRelationsWidget/EntityRelationsWidget.tsx
+++ b/src/components/widgets/EntityRelationsWidget/EntityRelationsWidget.tsx
@@ -611,7 +611,7 @@ function getEntityRelatedFromSectionJSX(response: any, props: EntityRelationsWid
                         return (
                             <div key={p.toString() + randomString()}>
                                 <div>
-                                    <i>{label || p}</i>
+                                    <a style={{color: "black"}} href={p}><i>{label || p}</i></a>
                                 </div>
                                 <ul>
                                     {relatedFrom.filter((elem: any) => {return elem["property"] === p})

--- a/src/components/widgets/EntityRelationsWidget/EntityRelationsWidget.tsx
+++ b/src/components/widgets/EntityRelationsWidget/EntityRelationsWidget.tsx
@@ -68,7 +68,7 @@ function getSectionListElement(response: any, currentResponsePath: any, props: E
     if (typeof currentResponsePath === "string") {
         return getEntityLink(response, currentResponsePath, props);
     }
-    else if (typeof currentResponsePath === "object" && currentResponsePath["value"]) {
+    else if (typeof currentResponsePath === "object" && currentResponsePath["value"]) { // TODO: Concat with else part? See relatedFrom (Manchester syntax does not get displayed, but neither in ols4)
         return getEntityLink(response, currentResponsePath["value"], props);
     }
     else { // type === "object"
@@ -298,6 +298,42 @@ function getSubEntityOf(response: any, props: EntityRelationsWidgetProps) {
     }
 }
 
+function getRelatedFrom(response: any, props: EntityRelationsWidgetProps) {
+    if(response && response["relatedFrom"] !== undefined) {
+        const relatedFrom= response["relatedFrom"];
+
+        const predicates: string[] = Array.from(new Set(response["relatedFrom"].map((elem: any) => {return elem["property"]})));
+
+        return (<EuiFlexItem>
+            {
+                relatedFrom.length ?? -1 > 0 ? <b>Related from</b> : ""
+            }
+            <ul>
+                {
+                    predicates.map((p) => {
+                        const label = getLabel(response, p);
+                        return (
+                            <div key={p.toString() + randomString()}>
+                                <div>
+                                    <i>{label || p}</i>
+                                </div>
+                                <ul>
+                                    {relatedFrom.filter((elem: any) => {return elem["property"] === p})
+                                        .map((elem: object) => {
+                                            return(
+                                                <li key={randomString()}>{getSectionListElement(response, elem, props)}</li>
+                                            )
+                                        })}
+                                </ul>
+                            </div>
+                        );
+                    })
+                }
+            </ul>
+        </EuiFlexItem>);
+    }
+}
+
 function getDifferentFrom(response: any, props: EntityRelationsWidgetProps) {
     if(response && response["http://www.w3.org/2002/07/owl#differentFrom"] !== undefined) {
         const differentFrom = getSectionListJSX(response, props, "http://www.w3.org/2002/07/owl#differentFrom");
@@ -356,6 +392,7 @@ function EntityRelationsWidget(props: EntityRelationsWidgetProps) {
                     <EuiText {...rest}>
                         {getSubEntityOf(entityJson, props)}
                         {getDifferentFrom(entityJson, props)}
+                        {getRelatedFrom(entityJson, props)}
                     </EuiText>
                 }
             </EuiCard>

--- a/src/components/widgets/EntityRelationsWidget/EntityRelationsWidget.tsx
+++ b/src/components/widgets/EntityRelationsWidget/EntityRelationsWidget.tsx
@@ -358,6 +358,28 @@ function getRelatedFrom(response: any, props: EntityRelationsWidgetProps) {
     }
 }
 
+function getTypes(response: any, props: EntityRelationsWidgetProps) {
+    if(response && props.entityType === "individual" && response["http://www.w3.org/1999/02/22-rdf-syntax-ns#type"] !== undefined) {
+        const types = asArray(response["http://www.w3.org/1999/02/22-rdf-syntax-ns#type"]).filter((elem: any) => elem !== "http://www.w3.org/2002/07/owl#NamedIndividual" && elem !== "http://www.w3.org/2002/07/owl#Thing" && (!(typeof elem === "string") || !elem.startsWith("http://www.w3.org/2000/01/rdf-schema#")));
+
+        return (<EuiFlexItem>
+            {
+                types?.length ?? -1 > 0 ? <b>Type</b> : ""
+            }
+            {types.length === 1 ? (
+                    <p>{getSectionListElement(response, types[0], props)}</p>
+                ) :
+                <ul>
+                    {
+                        types.map((item: any) => {
+                            return (<li key={randomString()} >{getSectionListElement(response, item, props)}</li>);
+                        })
+                    }
+                </ul>}
+        </EuiFlexItem>);
+    }
+}
+
 function getDifferentFrom(response: any, props: EntityRelationsWidgetProps) {
     if(response && response["http://www.w3.org/2002/07/owl#differentFrom"] !== undefined) {
         const differentFrom = getSectionListJSX(response, props, "http://www.w3.org/2002/07/owl#differentFrom");
@@ -418,6 +440,7 @@ function EntityRelationsWidget(props: EntityRelationsWidgetProps) {
                 {isSuccessEntityRelation &&
                     <EuiText {...rest}>
                         {getSubEntityOf(entityJson, props)}
+                        {getTypes(entityJson, props)}
                         {getDifferentFrom(entityJson, props)}
                         {getRelatedFrom(entityJson, props)}
                         {getEquivalentTo(entityJson, props)}

--- a/src/components/widgets/EntityRelationsWidget/EntityRelationsWidget.tsx
+++ b/src/components/widgets/EntityRelationsWidget/EntityRelationsWidget.tsx
@@ -875,20 +875,18 @@ async function fetchEntityJson(api: OlsApi, props: EntityRelationsWidgetProps) {
 }
 
 function EntityRelationsWidget(props: EntityRelationsWidgetProps) {
-    const { api, iri, ontologyId, hasTitle = DEFAULT_HAS_TITLE, entityType, showBadges = true, parameter, ...rest } = props;
-
     // reset props so that default values get applied
     props = {
-        api: api,
-        iri: iri,
-        entityType: entityType,
-        ontologyId: ontologyId,
-        hasTitle: hasTitle,
-        showBadges: showBadges,
-        parameter: parameter,
+        api: props.api + (props.api[props.api.length - 1] === '/' ? "" : "/") + "v2",
+        iri: props.iri,
+        entityType: props.entityType,
+        ontologyId: props.ontologyId,
+        hasTitle: props.hasTitle || DEFAULT_HAS_TITLE,
+        showBadges: props.showBadges || true,
+        parameter: props.parameter,
     }
 
-    const olsApi = new OlsApi(api);
+    const olsApi = new OlsApi(props.api);
 
     /**
      * Used to fetch an entities' data to be shown in different sections
@@ -901,12 +899,12 @@ function EntityRelationsWidget(props: EntityRelationsWidgetProps) {
     } = useQuery(
         [
             "entityJson",
-            api,
-            iri,
-            ontologyId,
-            entityType,
-            parameter,
-            showBadges
+            props.api,
+            props.iri,
+            props.ontologyId,
+            props.entityType,
+            props.parameter,
+            props.showBadges
         ],
         async () => {
             return fetchEntityJson(olsApi, props);
@@ -926,7 +924,7 @@ function EntityRelationsWidget(props: EntityRelationsWidgetProps) {
             entityJson
         ],
         queryFn: async () => {
-            return (getEntityTypeName(entityType) === "class" && entityJson["hasDirectChildren"]) ? fetchInstances(olsApi, props) : [];
+            return (getEntityTypeName(props.entityType) === "class" && entityJson["hasDirectChildren"]) ? fetchInstances(olsApi, props) : [];
         },
         enabled: !!entityJson },
     );
@@ -934,13 +932,13 @@ function EntityRelationsWidget(props: EntityRelationsWidgetProps) {
     return (
         <>
             <EuiCard
-                title={hasTitle ? (getCapitalized(getEntityTypeName(entityType)) +" Relations") : ""}
+                title={props.hasTitle ? (getCapitalized(getEntityTypeName(props.entityType)) +" Relations") : ""}
                 layout="horizontal"
             >
                 {(isLoadingEntityRelation || isLoadingInstances) && <EuiLoadingSpinner size={'s'}/>}
                 {isErrorEntityRelation && <EuiText>Requested resource not available</EuiText>}
                 {(isSuccessEntityRelation && isSuccessInstances) &&
-                    <EuiText {...rest}>
+                    <EuiText>
                         {getIndividualTypesSectionJSX(entityJson, props)}
                         {getIndividualSameAsSectionJSX(entityJson, props)}
                         {getIndividualDifferentFromSectionJSX(entityJson, props)}

--- a/src/components/widgets/EntityRelationsWidget/EntityRelationsWidget.tsx
+++ b/src/components/widgets/EntityRelationsWidget/EntityRelationsWidget.tsx
@@ -68,7 +68,7 @@ function getEntityLink(response: any, iri: string) {
     // TODO: Badges for defined by etc.
 }
 
-function getSectionListElement(response: any, currentResponsePath: any, props: EntityRelationsWidgetProps): ReactJSXElement | undefined {
+function getSectionListElement(response: any, currentResponsePath: any): ReactJSXElement | undefined {
     if (typeof currentResponsePath === "string") {
         return getEntityLink(response, currentResponsePath);
     }
@@ -81,9 +81,9 @@ function getSectionListElement(response: any, currentResponsePath: any, props: E
             const onProperty = currentResponsePath["http://www.w3.org/2002/07/owl#onProperty"];
             return (
               <>
-                  {getSectionListElement(response, onProperty, props)}
+                  {getSectionListElement(response, onProperty)}
                   <i style={{color: "purple"}}> some </i>
-                  {getSectionListElement(response, asArray(someValuesFrom)[0], props)}
+                  {getSectionListElement(response, asArray(someValuesFrom)[0])}
               </>
             );
         }
@@ -93,9 +93,9 @@ function getSectionListElement(response: any, currentResponsePath: any, props: E
             const onProperty = currentResponsePath["http://www.w3.org/2002/07/owl#onProperty"];
             return (
                 <>
-                    {getSectionListElement(response, onProperty, props)}
+                    {getSectionListElement(response, onProperty)}
                     <i style={{color: "purple"}}> only </i>
-                    {getSectionListElement(response, asArray(allValuesFrom)[0], props)}
+                    {getSectionListElement(response, asArray(allValuesFrom)[0])}
                 </>
             );
         }
@@ -114,7 +114,7 @@ function getSectionListElement(response: any, currentResponsePath: any, props: E
                     );
                 }
                 elements.push(
-                    getSectionListElement(response, elem, props)
+                    getSectionListElement(response, elem)
                 );
             }
             elements.push(
@@ -141,7 +141,7 @@ function getSectionListElement(response: any, currentResponsePath: any, props: E
                     );
                 }
                 elements.push(
-                    getSectionListElement(response, elem, props)
+                    getSectionListElement(response, elem)
                 );
             }
             elements.push(
@@ -159,9 +159,9 @@ function getSectionListElement(response: any, currentResponsePath: any, props: E
             const onProperty = currentResponsePath["http://www.w3.org/2002/07/owl#onProperty"];
             return (
                 <>
-                    {getSectionListElement(response, onProperty, props)}
+                    {getSectionListElement(response, onProperty)}
                     <i style={{color: "purple"}}> value </i>
-                    {getSectionListElement(response, asArray(hasValue)[0], props)}
+                    {getSectionListElement(response, asArray(hasValue)[0])}
                 </>
             );
         }
@@ -171,9 +171,9 @@ function getSectionListElement(response: any, currentResponsePath: any, props: E
             const onProperty = currentResponsePath["http://www.w3.org/2002/07/owl#onProperty"];
             return (
                 <>
-                    {getSectionListElement(response, onProperty, props)}
+                    {getSectionListElement(response, onProperty)}
                     <i style={{color: "purple"}}> min </i>
-                    {getSectionListElement(response, asArray(minCardinality)[0], props)}
+                    {getSectionListElement(response, asArray(minCardinality)[0])}
                 </>
             );
         }
@@ -183,9 +183,9 @@ function getSectionListElement(response: any, currentResponsePath: any, props: E
             const onProperty = currentResponsePath["http://www.w3.org/2002/07/owl#onProperty"];
             return (
                 <>
-                    {getSectionListElement(response, onProperty, props)}
+                    {getSectionListElement(response, onProperty)}
                     <i style={{color: "purple"}}> max </i>
-                    {getSectionListElement(response, asArray(maxCardinality)[0], props)}
+                    {getSectionListElement(response, asArray(maxCardinality)[0])}
                 </>
             );
         }
@@ -195,9 +195,9 @@ function getSectionListElement(response: any, currentResponsePath: any, props: E
             const onProperty = currentResponsePath["http://www.w3.org/2002/07/owl#onProperty"];
             return (
                 <>
-                    {getSectionListElement(response, onProperty, props)}
+                    {getSectionListElement(response, onProperty)}
                     <i style={{color: "purple"}}> exactly </i>
-                    {getSectionListElement(response, asArray(cardinality)[0], props)}
+                    {getSectionListElement(response, asArray(cardinality)[0])}
                 </>
             );
         }
@@ -207,9 +207,9 @@ function getSectionListElement(response: any, currentResponsePath: any, props: E
             const onProperty = currentResponsePath["http://www.w3.org/2002/07/owl#onProperty"];
             return (
                 <>
-                    {getSectionListElement(response, onProperty, props)}
+                    {getSectionListElement(response, onProperty)}
                     <i style={{color: "purple"}}> Self </i>
-                    {getSectionListElement(response, asArray(hasSelf)[0], props)}
+                    {getSectionListElement(response, asArray(hasSelf)[0])}
                 </>
             );
         }
@@ -219,7 +219,7 @@ function getSectionListElement(response: any, currentResponsePath: any, props: E
             return (
                 <>
                     <i>not </i>
-                    {getSectionListElement(response, hasSelf, props)}
+                    {getSectionListElement(response, hasSelf)}
                 </>
             );
         }
@@ -240,7 +240,7 @@ function getSectionListElement(response: any, currentResponsePath: any, props: E
                     );
                 }
                 elements.push(
-                    getSectionListElement(response, elem, props)
+                    getSectionListElement(response, elem)
                 );
             }
             elements.push(
@@ -261,7 +261,7 @@ function getSectionListElement(response: any, currentResponsePath: any, props: E
                     <span key={randomString()} className="text-neutral-default">
                       &#40;
                     </span>
-                    {getSectionListElement(response, inverseOf, props)}
+                    {getSectionListElement(response, inverseOf)}
                     <span key={randomString()} className="text-neutral-default">
                       &#41;
                     </span>
@@ -277,9 +277,9 @@ function getSectionListElement(response: any, currentResponsePath: any, props: E
     }
 }
 
-function getSectionListJSX(response: any, props: EntityRelationsWidgetProps, sectionLabel: string) {
+function getSectionListJSX(response: any, sectionLabel: string) {
     return asArray(response[sectionLabel]).map((elem: any) => {
-        return getSectionListElement(response, elem, props);
+        return getSectionListElement(response, elem);
     });
 }
 
@@ -292,12 +292,12 @@ function getIndividualTypesSectionJSX(response: any, props: EntityRelationsWidge
                 types?.length ?? -1 > 0 ? <b>Type</b> : ""
             }
             {types.length === 1 ? (
-                    <p>{getSectionListElement(response, types[0], props)}</p>
+                    <p>{getSectionListElement(response, types[0])}</p>
                 ) :
                 <ul>
                     {
                         types.map((item: any) => {
-                            return (<li key={randomString()} >{getSectionListElement(response, item, props)}</li>);
+                            return (<li key={randomString()} >{getSectionListElement(response, item)}</li>);
                         })
                     }
                 </ul>}
@@ -307,7 +307,7 @@ function getIndividualTypesSectionJSX(response: any, props: EntityRelationsWidge
 
 function getIndividualSameAsSectionJSX(response: any, props: EntityRelationsWidgetProps) {
     if(response && props.entityType === "individual" && response["http://www.w3.org/2002/07/owl#sameAs"] !== undefined) {
-        const sameAs = getSectionListJSX(response, props, "http://www.w3.org/2002/07/owl#sameAs");
+        const sameAs = getSectionListJSX(response, "http://www.w3.org/2002/07/owl#sameAs");
 
         return (<EuiFlexItem>
             {
@@ -328,8 +328,8 @@ function getIndividualSameAsSectionJSX(response: any, props: EntityRelationsWidg
 }
 
 function getIndividualDifferentFromSectionJSX(response: any, props: EntityRelationsWidgetProps) {
-    if(response && response["http://www.w3.org/2002/07/owl#differentFrom"] !== undefined) {
-        const differentFrom = getSectionListJSX(response, props, "http://www.w3.org/2002/07/owl#differentFrom");
+    if(response && props.entityType === "individual" && response["http://www.w3.org/2002/07/owl#differentFrom"] !== undefined) {
+        const differentFrom = getSectionListJSX(response, "http://www.w3.org/2002/07/owl#differentFrom");
 
         return (<EuiFlexItem>
             {
@@ -351,7 +351,7 @@ function getIndividualDifferentFromSectionJSX(response: any, props: EntityRelati
 
 function getDisjointWithSectionJSX(response: any, props: EntityRelationsWidgetProps) {
     if(response && ["property", "class"].includes(getEntityTypeName(props.entityType)) && response["http://www.w3.org/2002/07/owl#disjointWith"] !== undefined) {
-        const disjointWiths = getSectionListJSX(response, props, "http://www.w3.org/2002/07/owl#disjointWith");
+        const disjointWiths = getSectionListJSX(response, "http://www.w3.org/2002/07/owl#disjointWith");
 
         return (<EuiFlexItem>
             {
@@ -373,7 +373,7 @@ function getDisjointWithSectionJSX(response: any, props: EntityRelationsWidgetPr
 
 function getPropertyInverseOfSectionJSX(response: any, props: EntityRelationsWidgetProps) {
     if(response && ["property"].includes(getEntityTypeName(props.entityType)) && response["http://www.w3.org/2002/07/owl#inverseOf"] !== undefined) {
-        const inverseOfs = getSectionListJSX(response, props, "http://www.w3.org/2002/07/owl#inverseOf");
+        const inverseOfs = getSectionListJSX(response, "http://www.w3.org/2002/07/owl#inverseOf");
 
         return (<EuiFlexItem>
             {
@@ -393,7 +393,24 @@ function getPropertyInverseOfSectionJSX(response: any, props: EntityRelationsWid
     }
 }
 
-function getPropertyChainsSectionJSX(response: any, props: EntityRelationsWidgetProps) {
+function getPropertyChainJSX(propertyChain: any[], response: any) {
+    return asArray(propertyChain).slice().reverse().map((propertyExpr, i) => { // using .slice() here is important because a mutation of propertyChain would trigger a useQuery()
+        return (
+            <span key={propertyExpr}>
+                {getSectionListElement(response, propertyExpr)}
+                <>
+                    {i < asArray(propertyChain).length - 1 && (
+                        <span style={{ color: "gray", fontSize: "small"}}>
+                          {" "}◂{" "}
+                        </span>
+                    )}
+                </>
+            </span>
+        );
+    });
+}
+
+function getPropertyChainSectionJSX(response: any, props: EntityRelationsWidgetProps) {
     if(response && ["property"].includes(getEntityTypeName(props.entityType)) && response["http://www.w3.org/2002/07/owl#propertyChainAxiom"] !== undefined) {
         const propertyChains = response["http://www.w3.org/2002/07/owl#propertyChainAxiom"];
 
@@ -404,40 +421,12 @@ function getPropertyChainsSectionJSX(response: any, props: EntityRelationsWidget
                 propertyChains.length ?? -1 > 0 ? <b>{!hasMultipleChains ? "Property chain" : "Property chains"}</b> : ""
             }
             {!hasMultipleChains ? (
-                    <p>{asArray(propertyChains).slice().reverse().map((propertyExpr, i) => {
-                        return (
-                            <span key={propertyExpr}>
-                                {getSectionListElement(response, propertyExpr, props)}
-                                <>
-                                    {i < asArray(propertyChains).length - 1 && (
-                                        <span style={{ color: "gray", fontSize: "small"}}>
-                                          {" "}◂{" "}
-                                        </span>
-                                    )}
-                                </>
-                            </span>
-                        )
-                    })}</p>
+                    <p>{getPropertyChainJSX(propertyChains, response)}</p>
                 ):
                 <ul>
                     {
                         propertyChains.map((item: any) => {
-                            return (<li key={randomString()} >{
-                                asArray(item).slice().reverse().map((propertyExpr, i) => {
-                                    return (
-                                        <span key={propertyExpr}>
-                                            {getSectionListElement(response, propertyExpr, props)}
-                                                        <>
-                                                {i < asArray(item).length - 1 && (
-                                                    <span style={{ color: "gray", fontSize: "small"}}>
-                                                      {" "}◂{" "}
-                                                    </span>
-                                                )}
-                                            </>
-                                        </span>
-                                    )
-                                })
-                            }</li>);
+                            return (<li key={randomString()}>{getPropertyChainJSX(item, response)}</li>);
                         })
                     }
                 </ul>}
@@ -446,8 +435,8 @@ function getPropertyChainsSectionJSX(response: any, props: EntityRelationsWidget
 }
 
 function getEntityEquivalentToSectionJSX(response: any, props: EntityRelationsWidgetProps) {
-    if(response && response["http://www.w3.org/2002/07/owl#equivalentClass"] !== undefined) {
-        const equivalents = getSectionListJSX(response, props, "http://www.w3.org/2002/07/owl#equivalentClass");
+    if(response && ["property", "class"].includes(getEntityTypeName(props.entityType)) && response["http://www.w3.org/2002/07/owl#equivalentClass"] !== undefined) {
+        const equivalents = getSectionListJSX(response, "http://www.w3.org/2002/07/owl#equivalentClass");
 
         return (<EuiFlexItem>
             {
@@ -463,8 +452,8 @@ function getEntityEquivalentToSectionJSX(response: any, props: EntityRelationsWi
 }
 
 function getSubentityOfSectionJSX(response: any, props: EntityRelationsWidgetProps) {
-    if(response && response["http://www.w3.org/2000/01/rdf-schema#sub"+getCapitalized(getEntityTypeName(props.entityType))+"Of"] !== undefined) {
-        const subEntityOf = getSectionListJSX(response, props, "http://www.w3.org/2000/01/rdf-schema#sub" + getCapitalized(getEntityTypeName(props.entityType)) + "Of");
+    if(response && ["property", "class"].includes(getEntityTypeName(props.entityType)) && response["http://www.w3.org/2000/01/rdf-schema#sub"+getCapitalized(getEntityTypeName(props.entityType))+"Of"] !== undefined) {
+        const subEntityOf = getSectionListJSX(response, "http://www.w3.org/2000/01/rdf-schema#sub" + getCapitalized(getEntityTypeName(props.entityType)) + "Of");
 
         return (<EuiFlexItem>
             {
@@ -485,7 +474,7 @@ function getSubentityOfSectionJSX(response: any, props: EntityRelationsWidgetPro
 }
 
 function getEntityRelatedFromSectionJSX(response: any, props: EntityRelationsWidgetProps) {
-    if(response && response["relatedFrom"] !== undefined) {
+    if(response && ["property", "class"].includes(getEntityTypeName(props.entityType)) && response["relatedFrom"] !== undefined) {
         const relatedFrom= response["relatedFrom"];
 
         const predicates: string[] = Array.from(new Set(response["relatedFrom"].map((elem: any) => {return elem["property"]})));
@@ -507,7 +496,7 @@ function getEntityRelatedFromSectionJSX(response: any, props: EntityRelationsWid
                                     {relatedFrom.filter((elem: any) => {return elem["property"] === p})
                                         .map((elem: object) => {
                                             return(
-                                                <li key={randomString()}>{getSectionListElement(response, elem, props)}</li>
+                                                <li key={randomString()}>{getSectionListElement(response, elem)}</li>
                                             )
                                         })}
                                 </ul>
@@ -520,7 +509,7 @@ function getEntityRelatedFromSectionJSX(response: any, props: EntityRelationsWid
     }
 }
 
-function getClassInstancesSectionJSX(response: any, props: EntityRelationsWidgetProps) {
+function getClassInstancesSectionJSX(response: any) {
     if(response !== undefined) {
         const instances = response;
 
@@ -615,11 +604,11 @@ function EntityRelationsWidget(props: EntityRelationsWidgetProps) {
                         {getIndividualDifferentFromSectionJSX(entityJson, props)}
                         {getDisjointWithSectionJSX(entityJson, props)}
                         {getPropertyInverseOfSectionJSX(entityJson, props)}
-                        {getPropertyChainsSectionJSX(entityJson, props)}
+                        {getPropertyChainSectionJSX(entityJson, props)}
                         {getEntityEquivalentToSectionJSX(entityJson, props)}
                         {getSubentityOfSectionJSX(entityJson, props)}
                         {getEntityRelatedFromSectionJSX(entityJson, props)}
-                        {getClassInstancesSectionJSX(instancesJson, props)}
+                        {getClassInstancesSectionJSX(instancesJson)}
                     </EuiText>
                 }
             </EuiCard>

--- a/src/components/widgets/EntityRelationsWidget/EntityRelationsWidget.tsx
+++ b/src/components/widgets/EntityRelationsWidget/EntityRelationsWidget.tsx
@@ -178,21 +178,8 @@ function getDifferentFrom(response: any, props: EntityRelationsWidgetProps) {
 }
 
 async function getEntityJson(api: OlsApi, entityType: string, iri: string, ontologyId?: string, parameter?: string) {
-    if (entityType == "term" || entityType == "class") {
-        return await api.getClass(undefined, undefined, {ontologyId: ontologyId, termIri: iri}, parameter)
-            .catch((error) => console.log(error));
-    }
-    else if (entityType == "property") {
-        return await api.getProperty(undefined, undefined, {ontologyId: ontologyId, propertyIri: iri})
-            .catch((error) => console.log(error));
-    }
-    else if (entityType == "individual") {
-        return await api.getIndividual(undefined, undefined, {ontologyId: ontologyId, individualIri: iri})
-            .catch((error) => console.log(error));
-    }
-    else {
-        throw Error("Unexpected entity type. Has to be one of: 'term', 'class', 'property', 'individual'");
-    }
+    return await api.getEntity(undefined, undefined, {ontologyId: ontologyId, termIri: iri}, parameter)
+        .catch((error) => console.log(error));
 }
 
 function EntityRelationsWidget(props: EntityRelationsWidgetProps) {

--- a/src/components/widgets/EntityRelationsWidget/EntityRelationsWidget.tsx
+++ b/src/components/widgets/EntityRelationsWidget/EntityRelationsWidget.tsx
@@ -747,7 +747,7 @@ function EntityRelationsWidget(props: EntityRelationsWidgetProps) {
                 layout="horizontal"
             >
                 {(isLoadingEntityRelation || isLoadingInstances) && <EuiLoadingSpinner size={'s'}/>}
-                {isErrorEntityRelation && <EuiText>Terminology is not available</EuiText>}
+                {isErrorEntityRelation && <EuiText>Requested resource not available</EuiText>}
                 {(isSuccessEntityRelation && isSuccessInstances) &&
                     <EuiText {...rest}>
                         {getIndividualTypesSectionJSX(entityJson, props)}

--- a/src/components/widgets/EntityRelationsWidget/EntityRelationsWidget.tsx
+++ b/src/components/widgets/EntityRelationsWidget/EntityRelationsWidget.tsx
@@ -3,6 +3,7 @@ import { OlsApi } from "../../../api/OlsApi";
 import { useQuery } from "react-query";
 import {EuiCard, EuiFlexItem, EuiLoadingSpinner, EuiText} from "@elastic/eui";
 import {ReactJSXElement} from "@emotion/react/types/jsx-namespace";
+import {eq} from "@elastic/eui/src/components/search_bar/query/operators";
 
 export interface EntityRelationsWidgetProps {
     api: string;
@@ -59,7 +60,7 @@ function getEntityLink(response: any, iri: string, props: EntityRelationsWidgetP
         );
     }
 
-    return <a href={iri}><i>{label}</i></a>;
+    return <a href={iri}>{label}</a>;
 
     // TODO: Badges for defined by etc.
 }
@@ -287,12 +288,32 @@ function getSubEntityOf(response: any, props: EntityRelationsWidgetProps) {
             {
                 subEntityOf.length ?? -1 > 0 ? <b>Sub{getEntityTypeName(props.entityType)} of</b> : ""
             }
+            {subEntityOf.length === 1 ? (
+                <p>{subEntityOf[0]}</p>
+            ):
             <ul>
                 {
                     subEntityOf.map((item) => {
                         return (<li key={randomString()} >{item}</li>);
                     })
                 }
+            </ul>}
+        </EuiFlexItem>);
+    }
+}
+
+function getEquivalentTo(response: any, props: EntityRelationsWidgetProps) {
+    if(response && response["http://www.w3.org/2002/07/owl#equivalentClass"] !== undefined) {
+        const equivalents = getSectionListJSX(response, props, "http://www.w3.org/2002/07/owl#equivalentClass");
+
+        return (<EuiFlexItem>
+            {
+                equivalents.length ?? -1 > 0 ? <b>Equivalent to</b> : ""
+            }
+            <ul>
+                {equivalents.map((elem) => {
+                  return (<li key={randomString()}>{elem}</li>);
+                })}
             </ul>
         </EuiFlexItem>);
     }
@@ -342,13 +363,16 @@ function getDifferentFrom(response: any, props: EntityRelationsWidgetProps) {
             {
                 differentFrom?.length ?? -1 > 0 ? <b>Different from</b> : ""
             }
+            {differentFrom.length === 1 ? (
+                <p>{differentFrom[0]}</p>
+            ) :
             <ul>
                 {
                     differentFrom.map((item) => {
                         return (<li key={randomString()} >{item}</li>);
                     })
                 }
-            </ul>
+            </ul>}
         </EuiFlexItem>);
     }
 }
@@ -393,6 +417,7 @@ function EntityRelationsWidget(props: EntityRelationsWidgetProps) {
                         {getSubEntityOf(entityJson, props)}
                         {getDifferentFrom(entityJson, props)}
                         {getRelatedFrom(entityJson, props)}
+                        {getEquivalentTo(entityJson, props)}
                     </EuiText>
                 }
             </EuiCard>

--- a/src/components/widgets/EntityRelationsWidget/EntityRelationsWidget.tsx
+++ b/src/components/widgets/EntityRelationsWidget/EntityRelationsWidget.tsx
@@ -257,10 +257,10 @@ function getSectionListElement(response: any, currentResponsePath: any, props: E
         if (inverseOf) {
             return (
                 <>
+                    <i style={{color: "purple"}}>inverse </i>
                     <span key={randomString()} className="text-neutral-default">
                       &#40;
                     </span>
-                    <i>inverse </i>
                     {getSectionListElement(response, inverseOf, props)}
                     <span key={randomString()} className="text-neutral-default">
                       &#41;
@@ -283,7 +283,186 @@ function getSectionListJSX(response: any, props: EntityRelationsWidgetProps, sec
     });
 }
 
-function getSubEntityOf(response: any, props: EntityRelationsWidgetProps) {
+function getIndividualTypesSectionJSX(response: any, props: EntityRelationsWidgetProps) {
+    if(response && props.entityType === "individual" && response["http://www.w3.org/1999/02/22-rdf-syntax-ns#type"] !== undefined) {
+        const types = asArray(response["http://www.w3.org/1999/02/22-rdf-syntax-ns#type"]).filter((elem: any) => elem !== "http://www.w3.org/2002/07/owl#NamedIndividual" && (!(typeof elem === "string") || !elem.startsWith("http://www.w3.org/2000/01/rdf-schema#")));
+
+        return (<EuiFlexItem>
+            {
+                types?.length ?? -1 > 0 ? <b>Type</b> : ""
+            }
+            {types.length === 1 ? (
+                    <p>{getSectionListElement(response, types[0], props)}</p>
+                ) :
+                <ul>
+                    {
+                        types.map((item: any) => {
+                            return (<li key={randomString()} >{getSectionListElement(response, item, props)}</li>);
+                        })
+                    }
+                </ul>}
+        </EuiFlexItem>);
+    }
+}
+
+function getIndividualSameAsSectionJSX(response: any, props: EntityRelationsWidgetProps) {
+    if(response && props.entityType === "individual" && response["http://www.w3.org/2002/07/owl#sameAs"] !== undefined) {
+        const sameAs = getSectionListJSX(response, props, "http://www.w3.org/2002/07/owl#sameAs");
+
+        return (<EuiFlexItem>
+            {
+                sameAs?.length ?? -1 > 0 ? <b>Same As</b> : ""
+            }
+            {sameAs.length === 1 ? (
+                    <p>{sameAs[0]}</p>
+                ) :
+                <ul>
+                    {
+                        sameAs.map((item: any) => {
+                            return (<li key={randomString()} >{item}</li>);
+                        })
+                    }
+                </ul>}
+        </EuiFlexItem>);
+    }
+}
+
+function getIndividualDifferentFromSectionJSX(response: any, props: EntityRelationsWidgetProps) {
+    if(response && response["http://www.w3.org/2002/07/owl#differentFrom"] !== undefined) {
+        const differentFrom = getSectionListJSX(response, props, "http://www.w3.org/2002/07/owl#differentFrom");
+
+        return (<EuiFlexItem>
+            {
+                differentFrom?.length ?? -1 > 0 ? <b>Different from</b> : ""
+            }
+            {differentFrom.length === 1 ? (
+                    <p>{differentFrom[0]}</p>
+                ) :
+                <ul>
+                    {
+                        differentFrom.map((item) => {
+                            return (<li key={randomString()} >{item}</li>);
+                        })
+                    }
+                </ul>}
+        </EuiFlexItem>);
+    }
+}
+
+function getDisjointWithSectionJSX(response: any, props: EntityRelationsWidgetProps) {
+    if(response && ["property", "class"].includes(getEntityTypeName(props.entityType)) && response["http://www.w3.org/2002/07/owl#disjointWith"] !== undefined) {
+        const disjointWiths = getSectionListJSX(response, props, "http://www.w3.org/2002/07/owl#disjointWith");
+
+        return (<EuiFlexItem>
+            {
+                disjointWiths.length ?? -1 > 0 ? <b>Disjoint with</b> : ""
+            }
+            {disjointWiths.length === 1 ? (
+                    <p>{disjointWiths[0]}</p>
+                ):
+                <ul>
+                    {
+                        disjointWiths.map((item) => {
+                            return (<li key={randomString()} >{item}</li>);
+                        })
+                    }
+                </ul>}
+        </EuiFlexItem>);
+    }
+}
+
+function getPropertyInverseOfSectionJSX(response: any, props: EntityRelationsWidgetProps) {
+    if(response && ["property"].includes(getEntityTypeName(props.entityType)) && response["http://www.w3.org/2002/07/owl#inverseOf"] !== undefined) {
+        const inverseOfs = getSectionListJSX(response, props, "http://www.w3.org/2002/07/owl#inverseOf");
+
+        return (<EuiFlexItem>
+            {
+                inverseOfs.length ?? -1 > 0 ? <b>Inverse of</b> : ""
+            }
+            {inverseOfs.length === 1 ? (
+                    <p>{inverseOfs[0]}</p>
+                ):
+                <ul>
+                    {
+                        inverseOfs.map((item) => {
+                            return (<li key={randomString()} >{item}</li>);
+                        })
+                    }
+                </ul>}
+        </EuiFlexItem>);
+    }
+}
+
+function getPropertyChainsSectionJSX(response: any, props: EntityRelationsWidgetProps) {
+    if(response && ["property"].includes(getEntityTypeName(props.entityType)) && response["http://www.w3.org/2002/07/owl#propertyChainAxiom"] !== undefined) {
+        const propertyChains = response["http://www.w3.org/2002/07/owl#propertyChainAxiom"];
+
+        const hasMultipleChains = propertyChains.filter((elem: any) => Array.isArray(elem)).length > 0;
+
+        return (<EuiFlexItem>
+            {
+                propertyChains.length ?? -1 > 0 ? <b>{!hasMultipleChains ? "Property chain" : "Property chains"}</b> : ""
+            }
+            {!hasMultipleChains ? (
+                    <p>{asArray(propertyChains).slice().reverse().map((propertyExpr, i) => {
+                        return (
+                            <span key={propertyExpr}>
+                                {getSectionListElement(response, propertyExpr, props)}
+                                <>
+                                    {i < asArray(propertyChains).length - 1 && (
+                                        <span style={{ color: "gray", fontSize: "small"}}>
+                                          {" "}◂{" "}
+                                        </span>
+                                    )}
+                                </>
+                            </span>
+                        )
+                    })}</p>
+                ):
+                <ul>
+                    {
+                        propertyChains.map((item: any) => {
+                            return (<li key={randomString()} >{
+                                asArray(item).slice().reverse().map((propertyExpr, i) => {
+                                    return (
+                                        <span key={propertyExpr}>
+                                            {getSectionListElement(response, propertyExpr, props)}
+                                                        <>
+                                                {i < asArray(item).length - 1 && (
+                                                    <span style={{ color: "gray", fontSize: "small"}}>
+                                                      {" "}◂{" "}
+                                                    </span>
+                                                )}
+                                            </>
+                                        </span>
+                                    )
+                                })
+                            }</li>);
+                        })
+                    }
+                </ul>}
+        </EuiFlexItem>);
+    }
+}
+
+function getEntityEquivalentToSectionJSX(response: any, props: EntityRelationsWidgetProps) {
+    if(response && response["http://www.w3.org/2002/07/owl#equivalentClass"] !== undefined) {
+        const equivalents = getSectionListJSX(response, props, "http://www.w3.org/2002/07/owl#equivalentClass");
+
+        return (<EuiFlexItem>
+            {
+                equivalents.length ?? -1 > 0 ? <b>Equivalent to</b> : ""
+            }
+            <ul>
+                {equivalents.map((elem) => {
+                    return (<li key={randomString()}>{elem}</li>);
+                })}
+            </ul>
+        </EuiFlexItem>);
+    }
+}
+
+function getSubentityOfSectionJSX(response: any, props: EntityRelationsWidgetProps) {
     if(response && response["http://www.w3.org/2000/01/rdf-schema#sub"+getCapitalized(getEntityTypeName(props.entityType))+"Of"] !== undefined) {
         const subEntityOf = getSectionListJSX(response, props, "http://www.w3.org/2000/01/rdf-schema#sub" + getCapitalized(getEntityTypeName(props.entityType)) + "Of");
 
@@ -305,24 +484,7 @@ function getSubEntityOf(response: any, props: EntityRelationsWidgetProps) {
     }
 }
 
-function getEquivalentTo(response: any, props: EntityRelationsWidgetProps) {
-    if(response && response["http://www.w3.org/2002/07/owl#equivalentClass"] !== undefined) {
-        const equivalents = getSectionListJSX(response, props, "http://www.w3.org/2002/07/owl#equivalentClass");
-
-        return (<EuiFlexItem>
-            {
-                equivalents.length ?? -1 > 0 ? <b>Equivalent to</b> : ""
-            }
-            <ul>
-                {equivalents.map((elem) => {
-                  return (<li key={randomString()}>{elem}</li>);
-                })}
-            </ul>
-        </EuiFlexItem>);
-    }
-}
-
-function getRelatedFrom(response: any, props: EntityRelationsWidgetProps) {
+function getEntityRelatedFromSectionJSX(response: any, props: EntityRelationsWidgetProps) {
     if(response && response["relatedFrom"] !== undefined) {
         const relatedFrom= response["relatedFrom"];
 
@@ -358,52 +520,46 @@ function getRelatedFrom(response: any, props: EntityRelationsWidgetProps) {
     }
 }
 
-function getTypes(response: any, props: EntityRelationsWidgetProps) {
-    if(response && props.entityType === "individual" && response["http://www.w3.org/1999/02/22-rdf-syntax-ns#type"] !== undefined) {
-        const types = asArray(response["http://www.w3.org/1999/02/22-rdf-syntax-ns#type"]).filter((elem: any) => elem !== "http://www.w3.org/2002/07/owl#NamedIndividual" && (!(typeof elem === "string") || !elem.startsWith("http://www.w3.org/2000/01/rdf-schema#")));
+function getClassInstancesSectionJSX(response: any, props: EntityRelationsWidgetProps) {
+    if(response !== undefined) {
+        const instances = response;
 
-        return (<EuiFlexItem>
-            {
-                types?.length ?? -1 > 0 ? <b>Type</b> : ""
-            }
-            {types.length === 1 ? (
-                    <p>{getSectionListElement(response, types[0], props)}</p>
-                ) :
+        console.dir(instances);
+
+        if(instances.length > 0) {
+            return (<EuiFlexItem>
+                {
+                    <b>Instances</b>
+                }
                 <ul>
                     {
-                        types.map((item: any) => {
-                            return (<li key={randomString()} >{getSectionListElement(response, item, props)}</li>);
+                        instances.map((item: any) => {
+                            console.dir(item);
+                            return (<li key={randomString()} ><a href={item["iri"]}>{item["label"]}</a></li>);
                         })
                     }
-                </ul>}
-        </EuiFlexItem>);
+                </ul>
+            </EuiFlexItem>);
+        }
+
     }
 }
 
-function getDifferentFrom(response: any, props: EntityRelationsWidgetProps) {
-    if(response && response["http://www.w3.org/2002/07/owl#differentFrom"] !== undefined) {
-        const differentFrom = getSectionListJSX(response, props, "http://www.w3.org/2002/07/owl#differentFrom");
-
-        return (<EuiFlexItem>
-            {
-                differentFrom?.length ?? -1 > 0 ? <b>Different from</b> : ""
-            }
-            {differentFrom.length === 1 ? (
-                <p>{differentFrom[0]}</p>
-            ) :
-            <ul>
-                {
-                    differentFrom.map((item) => {
-                        return (<li key={randomString()} >{item}</li>);
-                    })
-                }
-            </ul>}
-        </EuiFlexItem>);
+async function fetchInstances(api: OlsApi, props: EntityRelationsWidgetProps) {
+    if(getEntityTypeName(props.entityType) === "class") {
+        const doubleEncodedTermIri = encodeURIComponent(encodeURIComponent(props.iri));
+        const response = await api.getClassInstances(undefined, undefined, {ontologyId: props.ontologyId, termIri: doubleEncodedTermIri}, props.parameter)
+            .catch((error) => console.log(error));
+        console.dir(asArray(response["elements"]));
+        return asArray(response["elements"]);
+    }
+    else {
+        return [];
     }
 }
 
-async function getEntityJson(api: OlsApi, entityType: string, iri: string, ontologyId?: string, parameter?: string) {
-    const response = await api.getEntity(undefined, undefined, {ontologyId: ontologyId, termIri: iri}, parameter)
+async function fetchEntityJson(api: OlsApi, props: EntityRelationsWidgetProps) {
+    const response = await api.getEntity(undefined, undefined, {ontologyId: props.ontologyId, termIri: props.iri}, props.parameter)
         .catch((error) => console.log(error));
     return response["elements"][0];
 }
@@ -426,8 +582,23 @@ function EntityRelationsWidget(props: EntityRelationsWidgetProps) {
             parameter
         ],
         async () => {
-            return getEntityJson(olsApi, entityType, iri, ontologyId, parameter);
-        }
+            return fetchEntityJson(olsApi, props);
+        },
+    );
+
+    const {
+        data: instancesJson,
+        isLoading: isLoadingInstances,
+        isSuccess: isSuccessInstances,
+    } = useQuery({
+        queryKey: [
+            "instancesJson",
+            entityJson
+        ],
+        queryFn: async () => {
+            return (getEntityTypeName(entityType) === "class" && entityJson["hasDirectChildren"]) ? fetchInstances(olsApi, props) : [];
+        },
+        enabled: !!entityJson },
     );
 
     return (
@@ -436,14 +607,19 @@ function EntityRelationsWidget(props: EntityRelationsWidgetProps) {
                 title={hasTitle ? (getCapitalized(getEntityTypeName(entityType)) +" Relations") : ""}
                 layout="horizontal"
             >
-                {isLoadingEntityRelation && <EuiLoadingSpinner size={'s'}/>}
-                {isSuccessEntityRelation &&
+                {(isLoadingEntityRelation || isLoadingInstances) && <EuiLoadingSpinner size={'s'}/>}
+                {(isSuccessEntityRelation && isSuccessInstances) &&
                     <EuiText {...rest}>
-                        {getSubEntityOf(entityJson, props)}
-                        {getTypes(entityJson, props)}
-                        {getDifferentFrom(entityJson, props)}
-                        {getRelatedFrom(entityJson, props)}
-                        {getEquivalentTo(entityJson, props)}
+                        {getIndividualTypesSectionJSX(entityJson, props)}
+                        {getIndividualSameAsSectionJSX(entityJson, props)}
+                        {getIndividualDifferentFromSectionJSX(entityJson, props)}
+                        {getDisjointWithSectionJSX(entityJson, props)}
+                        {getPropertyInverseOfSectionJSX(entityJson, props)}
+                        {getPropertyChainsSectionJSX(entityJson, props)}
+                        {getEntityEquivalentToSectionJSX(entityJson, props)}
+                        {getSubentityOfSectionJSX(entityJson, props)}
+                        {getEntityRelatedFromSectionJSX(entityJson, props)}
+                        {getClassInstancesSectionJSX(instancesJson, props)}
                     </EuiText>
                 }
             </EuiCard>

--- a/src/components/widgets/EntityRelationsWidget/EntityRelationsWidget.tsx
+++ b/src/components/widgets/EntityRelationsWidget/EntityRelationsWidget.tsx
@@ -260,7 +260,7 @@ function getSectionListElement(response: any, currentResponsePath: any): JSX.Ele
                     &#123;
                 </span>
             ];
-            for (const elem of unionOf) {
+            for (const elem of oneOf) {
                 if (elements.length > 1) {
                     elements.push(
                         <span key={randomString()} className="text-neutral-default">
@@ -604,7 +604,6 @@ function getEntityRelatedFromSectionJSX(response: any, props: EntityRelationsWid
             {
                 relatedFrom.length ?? -1 > 0 ? <b>Related from</b> : ""
             }
-            <ul>
                 {
                     predicates.map((p) => {
                         const label = getLabel(response, p);
@@ -613,7 +612,7 @@ function getEntityRelatedFromSectionJSX(response: any, props: EntityRelationsWid
                                 <div>
                                     <a style={{color: "black"}} href={p}><i>{label || p}</i></a>
                                 </div>
-                                <ul>
+                                <ul style={{marginBottom: 0}}>
                                     {relatedFrom.filter((elem: any) => {return elem["property"] === p})
                                         .map((elem: object) => {
                                             return(
@@ -621,11 +620,11 @@ function getEntityRelatedFromSectionJSX(response: any, props: EntityRelationsWid
                                             )
                                         })}
                                 </ul>
+                                <p></p> {/* Works as empty space left to next section */}
                             </div>
                         );
                     })
                 }
-            </ul>
         </EuiFlexItem>);
     }
     else {

--- a/src/components/widgets/EntityRelationsWidget/EntityRelationsWidget.tsx
+++ b/src/components/widgets/EntityRelationsWidget/EntityRelationsWidget.tsx
@@ -1,0 +1,146 @@
+import React from "react";
+import { OlsApi } from "../../../api/OlsApi";
+import { useQuery } from "react-query";
+import {EuiCard, EuiFlexItem, EuiLoadingSpinner, EuiText} from "@elastic/eui";
+
+export interface EntityRelationsWidgetProps {
+    api: string;
+    iri?: string;
+    ontologyId?: string;
+    hasTitle?: boolean;
+    entityType:
+        | "term" | "class" //equivalent: API uses 'class', rest uses 'term' -> both allowed here
+        | "individual"
+        | "property";
+    parameter?: string;
+}
+
+interface EntityRelation {
+    subEntityOf?: {
+        label: string,
+        iri: string
+    }[],
+    relatedFrom?: {
+        label: string,
+        category: string,
+    }[],
+    equivalentTo?: {
+        label: string,
+        category: string,
+    }[],
+    differentFrom?: {
+        label: string,
+        iri: string
+    }[],
+    entityTypeName: string
+}
+
+const DEFAULT_HAS_TITLE = true;
+
+function getCapitalized(text: string | undefined) : string | undefined {
+    if(text === undefined) return undefined;
+    return text.charAt(0).toUpperCase() + text.slice(1);
+}
+
+async function getEntityRelation(api: OlsApi, entityType: string, iri: string, ontologyId?: string, parameter?: string) {
+    const returnVal: EntityRelation = {entityTypeName: entityType === "term" ? "class" : entityType};
+
+    let response: any = "";
+
+    if (entityType == "term" || entityType == "class") {
+        response = await api.getClass(undefined, undefined, {ontologyId: ontologyId, termIri: iri}, parameter)
+            .catch((error) => console.log(error));
+    }
+    else if (entityType == "property") {
+        response = await api.getProperty(undefined, undefined, {ontologyId: ontologyId, propertyIri: iri})
+            .catch((error) => console.log(error));
+    }
+    else if (entityType == "individual") {
+        response = await api.getIndividual(undefined, undefined, {ontologyId: ontologyId, individualIri: iri})
+            .catch((error) => console.log(error));
+    }
+
+    if(response.elements[0]) {
+        if(response.elements[0]["http://www.w3.org/2000/01/rdf-schema#sub"+getCapitalized(returnVal.entityTypeName)+"Of"] !== undefined) {
+            returnVal.subEntityOf = !Array.isArray(response.elements[0]["http://www.w3.org/2000/01/rdf-schema#sub"+getCapitalized(returnVal.entityTypeName)+"Of"]) ?
+                [{
+                    label: response.elements[0]["linkedEntities"][response.elements[0]["http://www.w3.org/2000/01/rdf-schema#sub"+getCapitalized(returnVal.entityTypeName)+"Of"]].label,
+                    iri: response.elements[0]["linkedEntities"][response.elements[0]["http://www.w3.org/2000/01/rdf-schema#sub"+getCapitalized(returnVal.entityTypeName)+"Of"]]
+                }] :
+                response.elements[0]["http://www.w3.org/2000/01/rdf-schema#sub"+getCapitalized(returnVal.entityTypeName)+"Of"].map((elem: string) => {
+                    return {
+                        label: response.elements[0]["linkedEntities"][elem].label,
+                        iri: elem,
+                    }
+                });
+        }
+        returnVal.differentFrom = response.elements[0]["http://www.w3.org/2002/07/owl#differentFrom"];
+    }
+
+
+    return returnVal;
+}
+
+function EntityRelationsWidget(props: EntityRelationsWidgetProps) {
+    const { api, iri, ontologyId, hasTitle = DEFAULT_HAS_TITLE, entityType, parameter, ...rest } = props;
+    const olsApi = new OlsApi(api);
+
+    const {
+        data: entityRelation,
+        isLoading: isLoadingEntityRelation,
+        isSuccess: isSuccessEntityRelation,
+    } = useQuery(
+        [
+            "entityRelation",
+            api,
+            iri,
+            ontologyId,
+            entityType,
+            parameter
+        ],
+        async () => {
+            return getEntityRelation(olsApi, entityType, iri, ontologyId, parameter);
+        }
+    );
+
+    return (
+        <>
+            <EuiCard
+                title={hasTitle ? (getCapitalized(entityRelation?.entityTypeName) +" Relations") : ""}
+                layout="horizontal"
+            >
+                {isLoadingEntityRelation && <EuiLoadingSpinner size={'s'}/>}
+                {isSuccessEntityRelation &&
+                    <EuiText {...rest}>
+                        {entityRelation?.subEntityOf &&
+                            <EuiFlexItem>
+                                {
+                                    entityRelation?.subEntityOf?.length ?? -1 > 0 ? <b>Sub{entityRelation?.entityTypeName} of</b> : ""
+                                }
+                                <ul>
+                                    {entityRelation?.subEntityOf &&
+                                        entityRelation?.subEntityOf.map((item) => {return (<li>{item.label}</li>)})
+                                    }
+                                </ul>
+                            </EuiFlexItem>
+                        }
+                        {entityRelation?.differentFrom &&
+                            <EuiFlexItem>
+                                {
+                                    entityRelation?.differentFrom?.length ?? -1 > 0 ? <b>Different from</b> : ""
+                                }
+                                <ul>
+                                    {entityRelation?.differentFrom &&
+                                        entityRelation?.differentFrom.map((item) => {return (<li>{item}</li>)})
+                                    }
+                                </ul>
+                            </EuiFlexItem>
+                        }
+                    </EuiText>
+                }
+            </EuiCard>
+        </>
+    );
+}
+
+export { EntityRelationsWidget };

--- a/src/components/widgets/EntityRelationsWidget/EntityRelationsWidget.tsx
+++ b/src/components/widgets/EntityRelationsWidget/EntityRelationsWidget.tsx
@@ -208,7 +208,7 @@ function getSectionListElement(response: any, currentResponsePath: any, props: E
         const hasValue = currentResponsePath["http://www.w3.org/2002/07/owl#hasValue"];
         const minCardinality = currentResponsePath["http://www.w3.org/2002/07/owl#minCardinality"] || currentResponsePath["http://www.w3.org/2002/07/owl#minQualifiedCardinality"];
         const maxCardinality = currentResponsePath["http://www.w3.org/2002/07/owl#maxCardinality"] || currentResponsePath["http://www.w3.org/2002/07/owl#maxQualifiedCardinality"];
-        const cardinality = currentResponsePath["http://www.w3.org/2002/07/owl#cardinality"] || currentResponsePath["http://www.w3.org/2002/07/owl#cualifiedCardinality"];
+        const cardinality = currentResponsePath["http://www.w3.org/2002/07/owl#cardinality"] || currentResponsePath["http://www.w3.org/2002/07/owl#qualifiedCardinality"];
         const hasSelf = currentResponsePath["http://www.w3.org/2002/07/owl#hasSelf"];
         const complementOf = currentResponsePath["http://www.w3.org/2002/07/owl#complementOf"];
         const oneOf = currentResponsePath["http://www.w3.org/2002/07/owl#oneOf"];

--- a/src/components/widgets/EntityRelationsWidget/EntityRelationsWidget.tsx
+++ b/src/components/widgets/EntityRelationsWidget/EntityRelationsWidget.tsx
@@ -284,7 +284,7 @@ function getSectionListJSX(response: any, sectionLabel: string) {
 }
 
 function getIndividualTypesSectionJSX(response: any, props: EntityRelationsWidgetProps) {
-    if(response && props.entityType === "individual" && response["http://www.w3.org/1999/02/22-rdf-syntax-ns#type"] !== undefined) {
+    if(props.entityType === "individual" && response["http://www.w3.org/1999/02/22-rdf-syntax-ns#type"] !== undefined) {
         const types = asArray(response["http://www.w3.org/1999/02/22-rdf-syntax-ns#type"]).filter((elem: any) => elem !== "http://www.w3.org/2002/07/owl#NamedIndividual" && (!(typeof elem === "string") || !elem.startsWith("http://www.w3.org/2000/01/rdf-schema#")));
 
         return (<EuiFlexItem>
@@ -306,7 +306,7 @@ function getIndividualTypesSectionJSX(response: any, props: EntityRelationsWidge
 }
 
 function getIndividualSameAsSectionJSX(response: any, props: EntityRelationsWidgetProps) {
-    if(response && props.entityType === "individual" && response["http://www.w3.org/2002/07/owl#sameAs"] !== undefined) {
+    if(props.entityType === "individual" && response["http://www.w3.org/2002/07/owl#sameAs"] !== undefined) {
         const sameAs = getSectionListJSX(response, "http://www.w3.org/2002/07/owl#sameAs");
 
         return (<EuiFlexItem>
@@ -328,7 +328,7 @@ function getIndividualSameAsSectionJSX(response: any, props: EntityRelationsWidg
 }
 
 function getIndividualDifferentFromSectionJSX(response: any, props: EntityRelationsWidgetProps) {
-    if(response && props.entityType === "individual" && response["http://www.w3.org/2002/07/owl#differentFrom"] !== undefined) {
+    if(props.entityType === "individual" && response["http://www.w3.org/2002/07/owl#differentFrom"] !== undefined) {
         const differentFrom = getSectionListJSX(response, "http://www.w3.org/2002/07/owl#differentFrom");
 
         return (<EuiFlexItem>
@@ -350,7 +350,7 @@ function getIndividualDifferentFromSectionJSX(response: any, props: EntityRelati
 }
 
 function getDisjointWithSectionJSX(response: any, props: EntityRelationsWidgetProps) {
-    if(response && ["property", "class"].includes(getEntityTypeName(props.entityType)) && response["http://www.w3.org/2002/07/owl#disjointWith"] !== undefined) {
+    if(["property", "class"].includes(getEntityTypeName(props.entityType)) && response["http://www.w3.org/2002/07/owl#disjointWith"] !== undefined) {
         const disjointWiths = getSectionListJSX(response, "http://www.w3.org/2002/07/owl#disjointWith");
 
         return (<EuiFlexItem>
@@ -372,7 +372,7 @@ function getDisjointWithSectionJSX(response: any, props: EntityRelationsWidgetPr
 }
 
 function getPropertyInverseOfSectionJSX(response: any, props: EntityRelationsWidgetProps) {
-    if(response && ["property"].includes(getEntityTypeName(props.entityType)) && response["http://www.w3.org/2002/07/owl#inverseOf"] !== undefined) {
+    if(["property"].includes(getEntityTypeName(props.entityType)) && response["http://www.w3.org/2002/07/owl#inverseOf"] !== undefined) {
         const inverseOfs = getSectionListJSX(response, "http://www.w3.org/2002/07/owl#inverseOf");
 
         return (<EuiFlexItem>
@@ -411,7 +411,7 @@ function getPropertyChainJSX(propertyChain: any[], response: any) {
 }
 
 function getPropertyChainSectionJSX(response: any, props: EntityRelationsWidgetProps) {
-    if(response && ["property"].includes(getEntityTypeName(props.entityType)) && response["http://www.w3.org/2002/07/owl#propertyChainAxiom"] !== undefined) {
+    if(["property"].includes(getEntityTypeName(props.entityType)) && response["http://www.w3.org/2002/07/owl#propertyChainAxiom"] !== undefined) {
         const propertyChains = response["http://www.w3.org/2002/07/owl#propertyChainAxiom"];
 
         const hasMultipleChains = propertyChains.filter((elem: any) => Array.isArray(elem)).length > 0;
@@ -435,7 +435,7 @@ function getPropertyChainSectionJSX(response: any, props: EntityRelationsWidgetP
 }
 
 function getEntityEquivalentToSectionJSX(response: any, props: EntityRelationsWidgetProps) {
-    if(response && ["property", "class"].includes(getEntityTypeName(props.entityType)) && response["http://www.w3.org/2002/07/owl#equivalentClass"] !== undefined) {
+    if(["property", "class"].includes(getEntityTypeName(props.entityType)) && response["http://www.w3.org/2002/07/owl#equivalentClass"] !== undefined) {
         const equivalents = getSectionListJSX(response, "http://www.w3.org/2002/07/owl#equivalentClass");
 
         return (<EuiFlexItem>
@@ -452,7 +452,7 @@ function getEntityEquivalentToSectionJSX(response: any, props: EntityRelationsWi
 }
 
 function getSubentityOfSectionJSX(response: any, props: EntityRelationsWidgetProps) {
-    if(response && ["property", "class"].includes(getEntityTypeName(props.entityType)) && response["http://www.w3.org/2000/01/rdf-schema#sub"+getCapitalized(getEntityTypeName(props.entityType))+"Of"] !== undefined) {
+    if(["property", "class"].includes(getEntityTypeName(props.entityType)) && response["http://www.w3.org/2000/01/rdf-schema#sub"+getCapitalized(getEntityTypeName(props.entityType))+"Of"] !== undefined) {
         const subEntityOf = getSectionListJSX(response, "http://www.w3.org/2000/01/rdf-schema#sub" + getCapitalized(getEntityTypeName(props.entityType)) + "Of");
 
         return (<EuiFlexItem>
@@ -474,8 +474,8 @@ function getSubentityOfSectionJSX(response: any, props: EntityRelationsWidgetPro
 }
 
 function getEntityRelatedFromSectionJSX(response: any, props: EntityRelationsWidgetProps) {
-    if(response && ["property", "class"].includes(getEntityTypeName(props.entityType)) && response["relatedFrom"] !== undefined) {
-        const relatedFrom= response["relatedFrom"];
+    if(["property", "class"].includes(getEntityTypeName(props.entityType)) && response["relatedFrom"] !== undefined) {
+        const relatedFrom = response["relatedFrom"];
 
         const predicates: string[] = Array.from(new Set(response["relatedFrom"].map((elem: any) => {return elem["property"]})));
 
@@ -509,25 +509,20 @@ function getEntityRelatedFromSectionJSX(response: any, props: EntityRelationsWid
     }
 }
 
-function getClassInstancesSectionJSX(response: any) {
-    if(response !== undefined) {
-        const instances = response;
-
-        if(instances.length > 0) {
-            return (<EuiFlexItem>
+function getClassInstancesSectionJSX(instances: any) {
+    if(instances.length > 0) {
+        return (<EuiFlexItem>
+            {
+                <b>Instances</b>
+            }
+            <ul>
                 {
-                    <b>Instances</b>
+                    instances.map((item: any) => {
+                        return (<li key={randomString()} ><a href={item["iri"]}>{item["label"]}</a></li>);
+                    })
                 }
-                <ul>
-                    {
-                        instances.map((item: any) => {
-                            return (<li key={randomString()} ><a href={item["iri"]}>{item["label"]}</a></li>);
-                        })
-                    }
-                </ul>
-            </EuiFlexItem>);
-        }
-
+            </ul>
+        </EuiFlexItem>);
     }
 }
 
@@ -536,7 +531,12 @@ async function fetchInstances(api: OlsApi, props: EntityRelationsWidgetProps) {
         const doubleEncodedTermIri = encodeURIComponent(encodeURIComponent(props.iri));
         const response = await api.getClassInstances(undefined, undefined, {ontologyId: props.ontologyId, termIri: doubleEncodedTermIri}, props.parameter)
             .catch((error) => console.log(error));
-        return asArray(response["elements"]);
+        if (response["elements"] !== undefined) {
+            return asArray(response["elements"]);
+        }
+        else {
+            throw Error("Error fetching instances of '" + props.iri + "'");
+        }
     }
     else {
         return [];


### PR DESCRIPTION
Added <b>new</b> widget `EntityRelationsWidget` displaying an entity's relations to other entities in a similar way the [class relations section](https://gitlab.zbmed.de/km/semlookp/ols4/-/blob/dev/frontend/src/pages/ontologies/entities/EntityPage.tsx#L442-491) in [EBI-OLS](https://www.ebi.ac.uk/ols4)'s frontend does.

Current state:
All relations sections are incorporated into the widget, Badges can be turned on/off using the widget parameter `showBadges`. For more information see #29.

Some [TODOs](https://github.com/nfdi4health/semlookp-widgets/blob/02cc22d6c66b62731d04eac68e49dafb7747687e/src/components/widgets/EntityRelationsWidget/EntityRelationsWidget.tsx) (search for "TODO" in file) for the widget remain. #29 should therefore remain open after merging.