### PR TITLE
#11 autocomplete widget

### DIFF
--- a/src/components/widgets/AutocompleteWidget/AutocompleteWidget.stories.tsx
+++ b/src/components/widgets/AutocompleteWidget/AutocompleteWidget.stories.tsx
@@ -32,13 +32,18 @@ export default {
     allowCustomTerms: {
       description: "If true, custom terms that are not found in any ontology can be added.",
       type: { required: false},
+    },
+    singleSelection: {
+      description: "If true, only one concept can be selected at once.",
+      type: { required: false},
     }
   },
   args: {
     api: "https://semanticlookup.zbmed.de/ols/api/",
     parameter: "ontology=mesh,efo&type=class&collection=nfdi4health",
     hasShortSelectedLabel: true,
-    allowCustomTerms: false
+    allowCustomTerms: false,
+    singleSelection: true,
   }
 };
 const Template: ComponentStory<typeof AutocompleteWidget> = (args) => (

--- a/src/components/widgets/AutocompleteWidget/AutocompleteWidget.tsx
+++ b/src/components/widgets/AutocompleteWidget/AutocompleteWidget.tsx
@@ -65,6 +65,10 @@ export interface AutocompleteWidgetProps extends EuiComboBoxProps<string> {
      * If true, custom terms can be added that are not found via API.
      */
     allowCustomTerms: boolean;
+    /**
+     * If true, only one concept can be selected at once.
+     */
+    singleSelection: boolean;
 }
 
 /**
@@ -305,47 +309,91 @@ function AutocompleteWidget(props: AutocompleteWidgetProps) {
     setSelectedOptions([...selectedOptions, newOption]);
     }
 
-    if (props.allowCustomTerms) {
-        return (
-            <EuiComboBox
-                isClearable
-                aria-label="searchBar"
-                fullWidth={true}
-                {...rest} // items above can be overriden by a client
-                async={true}
-                isLoading={isLoadingTerms || isLoadingOnMount}
-                singleSelection={{ asPlainText: true }}
-                placeholder={
-                    props.placeholder ? props.placeholder : "Search for a Concept"
-                }
-                options={options}
-                selectedOptions={selectedOptions}
-                onSearchChange={setSearchValue}
-                onChange={onChangeHandler}
-                renderOption={renderOption}
-                onCreateOption={onCreateOptionHandler}
-            />
-        );
-    } else {
-        return (
-            <EuiComboBox
-                isClearable
-                aria-label="searchBar"
-                fullWidth={true}
-                {...rest} // items above can be overriden by a client
-                async={true}
-                isLoading={isLoadingTerms || isLoadingOnMount}
-                singleSelection={{ asPlainText: true }}
-                placeholder={
-                    props.placeholder ? props.placeholder : "Search for a Concept"
-                }
-                options={options}
-                selectedOptions={selectedOptions}
-                onSearchChange={setSearchValue}
-                onChange={onChangeHandler}
-                renderOption={renderOption}
-            />
-        );
+    if (props.singleSelection) {
+        if (props.allowCustomTerms) {
+            return (
+                <EuiComboBox
+                    isClearable
+                    aria-label="searchBar"
+                    fullWidth={true}
+                    {...rest} // items above can be overriden by a client
+                    async={true}
+                    isLoading={isLoadingTerms || isLoadingOnMount}
+                    singleSelection={{ asPlainText: true }}
+                    placeholder={
+                        props.placeholder ? props.placeholder : "Search for a Concept"
+                    }
+                    options={options}
+                    selectedOptions={selectedOptions}
+                    onSearchChange={setSearchValue}
+                    onChange={onChangeHandler}
+                    renderOption={renderOption}
+                    onCreateOption={onCreateOptionHandler}
+                />
+            );
+        } else {
+            return (
+                <EuiComboBox
+                    isClearable
+                    aria-label="searchBar"
+                    fullWidth={true}
+                    {...rest} // items above can be overriden by a client
+                    async={true}
+                    isLoading={isLoadingTerms || isLoadingOnMount}
+                    singleSelection={{ asPlainText: true }}
+                    placeholder={
+                        props.placeholder ? props.placeholder : "Search for a Concept"
+                    }
+                    options={options}
+                    selectedOptions={selectedOptions}
+                    onSearchChange={setSearchValue}
+                    onChange={onChangeHandler}
+                    renderOption={renderOption}
+                />
+            );
+        }
+    }
+    else {
+        if (props.allowCustomTerms) {
+            return (
+                <EuiComboBox
+                    isClearable
+                    aria-label="searchBar"
+                    fullWidth={true}
+                    {...rest} // items above can be overriden by a client
+                    async={true}
+                    isLoading={isLoadingTerms || isLoadingOnMount}
+                    placeholder={
+                        props.placeholder ? props.placeholder : "Search for a Concept"
+                    }
+                    options={options}
+                    selectedOptions={selectedOptions}
+                    onSearchChange={setSearchValue}
+                    onChange={onChangeHandler}
+                    renderOption={renderOption}
+                    onCreateOption={onCreateOptionHandler}
+                />
+            );
+        } else {
+            return (
+                <EuiComboBox
+                    isClearable
+                    aria-label="searchBar"
+                    fullWidth={true}
+                    {...rest} // items above can be overriden by a client
+                    async={true}
+                    isLoading={isLoadingTerms || isLoadingOnMount}
+                    placeholder={
+                        props.placeholder ? props.placeholder : "Search for a Concept"
+                    }
+                    options={options}
+                    selectedOptions={selectedOptions}
+                    onSearchChange={setSearchValue}
+                    onChange={onChangeHandler}
+                    renderOption={renderOption}
+                />
+            );
+        }
     }
 }
 

--- a/src/components/widgets/AutocompleteWidget/AutocompleteWidget.tsx
+++ b/src/components/widgets/AutocompleteWidget/AutocompleteWidget.tsx
@@ -220,32 +220,30 @@ function AutocompleteWidget(props: AutocompleteWidgetProps) {
             searchValue
         ],
         async () => {
-            if (searchValue.length > 0) {
-                return olsApi.select(
-                    {query: searchValue},
-                    undefined,
-                    undefined,
-                    parameter,
-                ).then((response) => {
-                    if (response.response && response.response.docs) {
-                        setOptions(response.response.docs.map((selection: any) => (
-                            {
-                                // label to display within the combobox either raw value or generated one
-                                // #renderOption() is used to display during selection.
-                                label: hasShortSelectedLabel ? selection.label : generateDisplayLabel(selection),
-                                // values to pass to clients
-                                value: {
-                                    iri: selection.iri,
-                                    label: selection.label,
-                                    ontology_name: selection.ontology_name,
-                                    type: selection.type,
-                                    short_form: selection.short_form,
-                                },
-                            })
-                        ));
-                    }
-                });
-            }
+            return olsApi.select(
+                {query: searchValue},
+                undefined,
+                undefined,
+                parameter,
+            ).then((response) => {
+                if (response.response && response.response.docs) {
+                    setOptions(response.response.docs.map((selection: any) => (
+                        {
+                            // label to display within the combobox either raw value or generated one
+                            // #renderOption() is used to display during selection.
+                            label: hasShortSelectedLabel ? selection.label : generateDisplayLabel(selection),
+                            // values to pass to clients
+                            value: {
+                                iri: selection.iri,
+                                label: selection.label,
+                                ontology_name: selection.ontology_name,
+                                type: selection.type,
+                                short_form: selection.short_form,
+                            },
+                        })
+                    ));
+                }
+            });
         }
     )
 
@@ -253,28 +251,26 @@ function AutocompleteWidget(props: AutocompleteWidgetProps) {
      * Once the set of selected options changes, pass the event by invoking the passed function.
      */
     useEffect(() => {
-        if (selectedOptions.length >= 1)  {
-            props.selectionChangedEvent(
-                selectedOptions.map((x) => {
-                    // return the value object with the raw values from OLS to a client
-                    if(props.allowCustomTerms && x.value.iri=="") {
-                        return {
-                            iri: "",
-                            label: x.label,
-                            ontology_name: "",
-                            type: ""
-                        };
-                    } else {
-                        return {
-                            iri: x.value.iri,
-                            label: x.value.label,
-                            ontology_name: x.value.ontology_name,
-                            type: x.value.type
-                        };
-                    }
-                })[0]
-            );
-        }
+        props.selectionChangedEvent(
+            selectedOptions.map((x) => {
+                // return the value object with the raw values from OLS to a client
+                if(props.allowCustomTerms && x.value.iri=="") {
+                    return {
+                        iri: "",
+                        label: x.label,
+                        ontology_name: "",
+                        type: ""
+                    };
+                } else {
+                    return {
+                        iri: x.value.iri,
+                        label: x.value.label,
+                        ontology_name: x.value.ontology_name,
+                        type: x.value.type
+                    };
+                }
+            })[0]
+        );
     }, [selectedOptions]);
 
     function generateDisplayLabel(item: any) {

--- a/src/components/widgets/AutocompleteWidget/AutocompleteWidget.tsx
+++ b/src/components/widgets/AutocompleteWidget/AutocompleteWidget.tsx
@@ -43,12 +43,12 @@ export interface AutocompleteWidgetProps extends EuiComboBoxProps<string> {
      * A method that is called once the set of selection changes
      * @param selectedOptions  The selected items
      */
-    selectionChangedEvent: (selectedOption: {
+    selectionChangedEvent: (selectedOptions: {
         label: string;
         iri?: string;
         ontology_name?: string;
         type?: string;
-    }) => void;
+    }[]) => void;
     /**
      * Pass a pre select value.
      */
@@ -271,7 +271,7 @@ function AutocompleteWidget(props: AutocompleteWidgetProps) {
                         type: x.value.type
                     };
                 }
-            })[0]
+            })
         );
     }, [selectedOptions]);
 

--- a/src/components/widgets/AutocompleteWidget/AutocompleteWidget.tsx
+++ b/src/components/widgets/AutocompleteWidget/AutocompleteWidget.tsx
@@ -220,30 +220,32 @@ function AutocompleteWidget(props: AutocompleteWidgetProps) {
             searchValue
         ],
         async () => {
-            return olsApi.select(
-                {query: searchValue},
-                undefined,
-                undefined,
-                parameter,
-            ).then((response) => {
-                if (response.response && response.response.docs) {
-                    setOptions(response.response.docs.map((selection: any) => (
-                        {
-                            // label to display within the combobox either raw value or generated one
-                            // #renderOption() is used to display during selection.
-                            label: hasShortSelectedLabel ? selection.label : generateDisplayLabel(selection),
-                            // values to pass to clients
-                            value: {
-                                iri: selection.iri,
-                                label: selection.label,
-                                ontology_name: selection.ontology_name,
-                                type: selection.type,
-                                short_form: selection.short_form,
-                            },
-                        })
-                    ));
-                }
-            });
+            if(searchValue.length > 0) {
+                return olsApi.select(
+                    {query: searchValue},
+                    undefined,
+                    undefined,
+                    parameter,
+                ).then((response) => {
+                    if (response.response && response.response.docs) {
+                        setOptions(response.response.docs.map((selection: any) => (
+                            {
+                                // label to display within the combobox either raw value or generated one
+                                // #renderOption() is used to display during selection.
+                                label: hasShortSelectedLabel ? selection.label : generateDisplayLabel(selection),
+                                // values to pass to clients
+                                value: {
+                                    iri: selection.iri,
+                                    label: selection.label,
+                                    ontology_name: selection.ontology_name,
+                                    type: selection.type,
+                                    short_form: selection.short_form,
+                                },
+                            })
+                        ));
+                    }
+                });
+            }
         }
     )
 

--- a/src/components/widgets/AutocompleteWidget/AutocompleteWidget.tsx
+++ b/src/components/widgets/AutocompleteWidget/AutocompleteWidget.tsx
@@ -243,7 +243,6 @@ function AutocompleteWidget(props: AutocompleteWidgetProps) {
                                 },
                             })
                         ));
-                        setSelectedOptions([]);
                     }
                 });
             }


### PR DESCRIPTION
Addresses two issues regarding the `AutocompleteWidget`:
- #11
- #43 

Additionally, the parameter `selectedOptions` of the property `selectionChangedEvent` now contains an array of all selected options instead of just one option. The comment above the property suggested that this is desired:

```javascript
/**
* A method that is called once the set of selection changes
* @param selectedOptions  The selected items
*/
selectionChangedEvent: (selectedOptions: {
        label: string;
        iri?: string;
        ontology_name?: string;
        type?: string;
}[]) => void;
```