### PR TITLE
fix: corrected key of the short_form for the OLS3 and OLS4 API.

### DIFF
--- a/src/model/ols3-model/OLS3Entity.ts
+++ b/src/model/ols3-model/OLS3Entity.ts
@@ -99,7 +99,7 @@ export abstract class OLS3Entity extends OLS3Thing implements Entity{
   }
 
   getShortForm(): string {
-    return this.properties["obo_id"] || this.properties["shortForm"];
+    return this.properties["obo_id"] || this.properties["short_form"];
   }
 
   // TODO: are the following 3 needed?

--- a/src/model/ols4-model/OLS4Entity.ts
+++ b/src/model/ols4-model/OLS4Entity.ts
@@ -88,7 +88,7 @@ export abstract class OLS4Entity extends OLS4Thing implements Entity{
   }
 
   getShortForm(): string {
-    return this.properties["curie"] || this.properties["short_form"];
+    return this.properties["curie"] || this.properties["shortForm"];
   }
 
   getDepictedBy(): Reified<string>[] {

--- a/src/model/ols4-model/OLS4Entity.ts
+++ b/src/model/ols4-model/OLS4Entity.ts
@@ -88,7 +88,7 @@ export abstract class OLS4Entity extends OLS4Thing implements Entity{
   }
 
   getShortForm(): string {
-    return this.properties["curie"] || this.properties["shortForm"];
+    return this.properties["curie"] || this.properties["short_form"];
   }
 
   getDepictedBy(): Reified<string>[] {


### PR DESCRIPTION
There was an issue in the spelling of the "short_form" key. Since this the breadcrumb widget had an issue displaying the "short_form". 