### PR TITLE
feat(ResourcesWidget): add navigation function parameter

### DIFF
--- a/src/components/widgets/ResourcesWidget/ResourcesWidget.stories.tsx
+++ b/src/components/widgets/ResourcesWidget/ResourcesWidget.stories.tsx
@@ -70,8 +70,10 @@ ResourcesWidget1.args = {
   pageSizeOptions: [10, 25, 50, 100],
   initialSortField: "config.preferredPrefix",
   initialSortDir: "asc" as const,
-  targetLink: "https://semanticlookup.zbmed.de/dev/",
-  parameter: "collection=nfdi4health"
+  parameter: "collection=nfdi4health",
+  onNavigateToOntology: (value: string) => (
+    console.log(`Navigating to ${value}`)
+ ),
 };
 export const WithActions = Template.bind({});
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -122,6 +124,8 @@ WithActionsAndSafety.args = {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   ...WithActions.args,
-  targetLink: "https://semanticlookup.zbmed.de/safety/",
   parameter: "collection=safety",
+  onNavigateToOntology: (value: string) => (
+    console.log(`Navigating to ${value}`)
+ ),
 };

--- a/src/components/widgets/ResourcesWidget/ResourcesWidget.tsx
+++ b/src/components/widgets/ResourcesWidget/ResourcesWidget.tsx
@@ -26,7 +26,7 @@ function ResourcesWidget(props: ResourcesWidgetProps) {
     pageSizeOptions = DEFAULT_PAGE_SIZE_OPTIONS,
     initialSortField = DEFAULT_INITIAL_SORT_FIELD,
     initialSortDir = DEFAULT_INITIAL_SORT_DIR,
-    targetLink,
+    onNavigateToOntology,
     parameter
   } = props;
   const olsApi = new OlsApi(api);
@@ -35,7 +35,6 @@ function ResourcesWidget(props: ResourcesWidgetProps) {
   const [pageSize, setPageSize] = useState(10);
   const [sortField, setSortField] = useState<string | number>(initialSortField);
   const [sortDirection, setSortDirection] = useState(initialSortDir);
-
 
   const columns: Array<EuiBasicTableColumn<OlsResource> & { css?: SerializedStyles }> = [
     {
@@ -48,7 +47,11 @@ function ResourcesWidget(props: ResourcesWidgetProps) {
       name: "Short Name",
       field: "config.preferredPrefix",
       render: (value: string) => (
-        targetLink ? <EuiLink href={targetLink + "ontologies/" + value.toLowerCase() + "/"}>{value}</EuiLink> : value
+        onNavigateToOntology ? (
+          <EuiLink onClick={() => onNavigateToOntology(value)}>{value}</EuiLink>
+        ) : (
+          value
+        )
       ),
       width: "10%",
       sortable: true

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -272,6 +272,12 @@ export type ResourcesWidgetProps = ApiObj & TargetLinkObj & ParameterObj & {
      * Pass actions to each item in the table.
      */
     actions?: Array<Action<OlsResource>>;
+
+    /**
+     * This function is called every time an ontology short name is clicked
+     * @param value ontology short name
+     */
+    onNavigateToOntology?: (value: string) => any;
 }
 
 export type OlsResource = ForcedOntologyIdObj & {


### PR DESCRIPTION
Similar as in https://github.com/nfdi4health/semlookp-widgets/pull/72
To navigate to the ontology info page. The user gets the ontology id if available and can define a navigation function based in these. 