### PR TITLE
fix(MetadataWidget): fix view for large hierarchies

### DIFF
--- a/src/components/widgets/MetadataWidget/MetadataWidget.stories.tsx
+++ b/src/components/widgets/MetadataWidget/MetadataWidget.stories.tsx
@@ -117,6 +117,21 @@ OLS4V2.args = {
   parameter: ""
 };
 
+export const OLS4V2LargeHierarchy = Template.bind({});
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+OLS4V2LargeHierarchy.storyName = "OLS4 V2 Large Hierarchy"
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+OLS4V2LargeHierarchy.args = {
+  api: "https://www.ebi.ac.uk/ols4/api/",
+  ontologyId: "ncbitaxon",
+  iri: "http://purl.obolibrary.org/obo/NCBITaxon_2489341",
+  entityType: "term",
+  useLegacy: false,
+  parameter: "",
+};
+
 export const SelectingDefiningOntology = Template.bind({});
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/src/components/widgets/MetadataWidget/MetadataWidget.tsx
+++ b/src/components/widgets/MetadataWidget/MetadataWidget.tsx
@@ -32,7 +32,7 @@ function MetadataWidget(props: MetadataWidgetProps) {
   function render(data: Entity) {
     return (
       <>
-        <EuiFlexGroup direction="column" style={{ maxWidth: 600 }}>
+        <EuiFlexGroup direction="column">
           <EuiFlexItem grow={false}>
                 <span>
                   <BreadcrumbPresentation
@@ -46,7 +46,7 @@ function MetadataWidget(props: MetadataWidgetProps) {
             <EuiFlexGroup direction="column">
               <EuiFlexItem>
                 <EuiFlexGroup>
-                  <EuiFlexItem grow={false}>
+                  <EuiFlexItem grow={false} style={{ maxWidth: 600 }}>
                     <IriWidget
                       iri={iri}
                       parameter={parameter}
@@ -54,20 +54,19 @@ function MetadataWidget(props: MetadataWidgetProps) {
                   </EuiFlexItem>
                 </EuiFlexGroup>
               </EuiFlexItem>
-              <EuiFlexItem grow={false}>
+              <EuiFlexItem grow={false} style={{ maxWidth: 600 }}>
                 <TitlePresentation
                   title={data.getLabel()}
                 />
               </EuiFlexItem>
             </EuiFlexGroup>
           </EuiFlexItem>
-          <EuiFlexItem>
+          <EuiFlexItem style={{ maxWidth: 600 }}>
             <DescriptionPresentation
               description={data.getDescription()}
             />
           </EuiFlexItem>
           <EuiFlexItem>
-            <div style={{ maxHeight: "500px", overflow: "auto" }}>
               <TabPresentation
                 data={data}
                 iri={iri}
@@ -76,7 +75,6 @@ function MetadataWidget(props: MetadataWidgetProps) {
                 ontologyId={props.ontologyId ? props.ontologyId : data.getOntologyId()}
                 useLegacy={useLegacy}
               />
-            </div>
           </EuiFlexItem>
         </EuiFlexGroup>
       </>

--- a/src/components/widgets/MetadataWidget/TabWidget/HierarchyWidget/HierarchyWidget.stories.tsx
+++ b/src/components/widgets/MetadataWidget/TabWidget/HierarchyWidget/HierarchyWidget.stories.tsx
@@ -63,3 +63,16 @@ HierarchyWidget1.args = {
   ontologyId: "efo",
   entityType: "class"
 };
+
+export const HierarchyWidgetLarge = Template.bind({});
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+HierarchyWidgetLarge.storyName = "Hierarchy Widget Large Hierarchy"
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+HierarchyWidgetLarge.args = {
+  api: "https://www.ebi.ac.uk/ols4/api/",
+  ontologyId: "ncbitaxon",
+  iri: "http://purl.obolibrary.org/obo/NCBITaxon_2489341",
+  entityType: "term",
+};

--- a/src/components/widgets/MetadataWidget/TabWidget/TabPresentation.tsx
+++ b/src/components/widgets/MetadataWidget/TabWidget/TabPresentation.tsx
@@ -21,7 +21,6 @@ function TabPresentation(props: TabPresentationProps) {
   function render(data: Entity) {
     return (
       <>
-        <EuiFlexItem>
           <EuiTabbedContent size="s" tabs={
             [
               {
@@ -34,6 +33,7 @@ function TabPresentation(props: TabPresentationProps) {
               {
                 content: (
                   <>
+                    <div style={{ overflow: "auto"}}>
                     {props.useLegacy == undefined || props.useLegacy
                       ? <HierarchyWidgetDeprecated
                         ontologyId={props.ontologyId || ((data && data.getOntologyId() !== undefined) ? data.getOntologyId() : "")}
@@ -48,6 +48,7 @@ function TabPresentation(props: TabPresentationProps) {
                         entityType={props.entityType}
                       />
                     }
+                    </div>
                   </>
                 ),
                 id: "tab2",
@@ -63,7 +64,6 @@ function TabPresentation(props: TabPresentationProps) {
               }
             ]
           } />
-        </EuiFlexItem>
       </>
     );
   }

--- a/src/components/widgets/MetadataWidget/TabWidget/TabWidget.stories.tsx
+++ b/src/components/widgets/MetadataWidget/TabWidget/TabWidget.stories.tsx
@@ -123,3 +123,18 @@ DefiningOntologyUnavailable.args = {  api: "https://www.ebi.ac.uk/ols4/api/",
   entityType: "term",
   parameter: ""
 };
+
+export const TabWidgetLarge = Template.bind({});
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+TabWidgetLarge.storyName = "Metadata Widget Large Hierarchy"
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+TabWidgetLarge.args = {
+  api: "https://www.ebi.ac.uk/ols4/api/",
+  ontologyId: "ncbitaxon",
+  iri: "http://purl.obolibrary.org/obo/NCBITaxon_2489341",
+  useLegacy: false,
+  parameter: ""
+};
+


### PR DESCRIPTION
Large hierarchies should no longer be truncated or run over the edge. Moved problematic inline styles to the correct positions. Added some stories for testing.