### PR TITLE
fix(AutocompleteWidget): show actions

### DIFF
--- a/src/components/widgets/AutocompleteWidget/AutocompleteWidget.stories.tsx
+++ b/src/components/widgets/AutocompleteWidget/AutocompleteWidget.stories.tsx
@@ -1,12 +1,15 @@
 import { AutocompleteWidget } from "./AutocompleteWidget";
 import "@elastic/eui/dist/eui_theme_light.json";
-import { AutocompleteWidgetStoryArgTypes, AutocompleteWidgetStoryArgs } from "./AutocompleteWidgetStories";
+import {
+  AutocompleteWidgetStoryArgTypes,
+  AutocompleteWidgetStoryArgsReact
+} from "./AutocompleteWidgetStories";
 
 export default {
   title: "AutocompleteWidget",
   component: AutocompleteWidget,
   ...AutocompleteWidgetStoryArgTypes,
-  ...AutocompleteWidgetStoryArgs,
+  ...AutocompleteWidgetStoryArgsReact,
 }
 
 export {

--- a/src/components/widgets/AutocompleteWidget/AutocompleteWidgetStories.ts
+++ b/src/components/widgets/AutocompleteWidget/AutocompleteWidgetStories.ts
@@ -28,6 +28,18 @@ export const AutocompleteWidgetStoryArgTypes = {
   }
 }
 
+export const AutocompleteWidgetStoryArgsReact = {
+  args: {
+    api: "https://semanticlookup.zbmed.de/ols/api/",
+    parameter: "ontology=mesh,efo&type=class&collection=nfdi4health&fieldList=description,label,iri,ontology_name,type,short_form",
+    hasShortSelectedLabel: true,
+    allowCustomTerms: false,
+    singleSelection: true,
+    placeholder: "Search for a Concept",
+    preselected: [],
+  },
+};
+
 export const AutocompleteWidgetStoryArgs = {
   args: {
     api: "https://semanticlookup.zbmed.de/ols/api/",


### PR DESCRIPTION
In the HTML stories, we're directly manipulating the DOM and using JavaScript to create and interact with widgets. When we define selectionChangedEvent as a function that does nothing (() => {return;}), we're essentially providing a placeholder for the event handler. This is necessary because the HTML widget expects a function to be passed as the selectionChangedEvent handler. If we don't provide a function, the widget might not initialize correctly or might not behave as expected when an event occurs.

In contrast, React stories are more integrated with Storybook's React environment, which includes support for actions. When we define an action in the story's argTypes, Storybook automatically creates a function that logs the event to the Storybook UI. This is why we don't need to explicitly define selectionChangedEvent as a function in the React stories. Instead, we define it in argTypes like so:
```
argTypes: {
 selectionChangedEvent: { action: 'selectionChangedEvent' },
},
```
This tells Storybook to create an action for selectionChangedEvent, which will be called with the event data whenever the event occurs in the component. This is a feature of Storybook's React environment and is not applicable to plain HTML widgets.

I separated AutocompleteWidgetStoryArgs (providing the function) and AutocompleteWidgetStoryArgsReact (not providing a function) and passed them to the corresponding HTML and React stories.